### PR TITLE
monitoring: silence rebuild noise with maintenance windows + retry tuning

### DIFF
--- a/.claude/rules/nixos-service-modules.md
+++ b/.claude/rules/nixos-service-modules.md
@@ -99,6 +99,34 @@ homelab.monitoring.monitors = [{
 }];
 ```
 
+**Noise discipline.** The monitor submodule has tuned defaults to keep Gotify
+signal-to-noise high — do NOT override these unless you have a concrete reason:
+
+- `interval = 60` — check cadence in seconds
+- `maxretries = 10` — consecutive failures before DOWN; with the 60s interval,
+  a monitor needs ~10 minutes of continuous failure before it pages. This
+  suppresses every transient blip from nightly rebuilds, container restarts,
+  and NFS hiccups.
+- `retryInterval = 60` — seconds between retries
+- `resendInterval = 240` — heartbeats between re-notifications while still
+  DOWN; at interval=60s, ≈4h. Ensures a persistent outage re-pages so you
+  notice if you missed the first alert.
+
+If you bump `interval` on a monitor, remember `resendInterval` is measured
+in heartbeats, not minutes — recompute it so the re-page cadence stays ~4h.
+
+**Maintenance windows.** Fleet-wide noise windows (e.g. the nightly auto-update
+window) live on the host running Uptime Kuma — see
+`modules/nixos/services/uptime-kuma.nix`. Declare each window exactly once,
+on that host, to avoid cross-host sync races. The sync service creates and
+updates windows declaratively via
+`homelab.monitoring.maintenanceWindows = [{ title; startTime; endTime; ... }]`.
+By default a window applies to every monitor in Kuma
+(`appliesToAllMonitors = true`).
+
+Do NOT add a new maintenance window for a one-off service restart — bump the
+service's `maxretries` instead, or just accept the alert.
+
 ### NFS Watchdog (for NFS-dependent services)
 
 ```nix

--- a/modules/nixos/services/monitoring_sync.nix
+++ b/modules/nixos/services/monitoring_sync.nix
@@ -5,7 +5,7 @@
   ...
 }: let
   cfg = config.homelab.monitoring;
-  haveMonitors = cfg.monitors != [];
+  haveMonitoringConfig = cfg.monitors != [] || cfg.maintenanceWindows != [];
 
   monitorsJson = pkgs.writeTextFile {
     name = "homelab-monitors.json";
@@ -269,7 +269,7 @@
                     title = entry["title"]
                     description = entry.get("description", "")
                     active = bool(entry.get("active", True))
-                    timezone = entry.get("timezone", "Australia/Perth")
+                    timezone_option = entry.get("timezone", "Australia/Perth")
                     strategy_str = entry.get("strategy", "recurring-interval")
                     interval_day = int(entry.get("intervalDay", 1))
                     start_time = entry.get("startTime", "00:00")
@@ -295,7 +295,7 @@
                         intervalDay=interval_day,
                         dateRange=date_range,
                         timeRange=time_range,
-                        timezone=timezone,
+                        timezoneOption=timezone_option,
                         weekdays=[],
                         daysOfMonth=[],
                     )
@@ -564,7 +564,7 @@ in {
     };
   };
 
-  config = lib.mkIf (cfg.enable && haveMonitors) {
+  config = lib.mkIf (cfg.enable && haveMonitoringConfig) {
     sops.secrets."uptime-kuma/env" = {
       sopsFile = cfg.authSecret;
       format = "dotenv";

--- a/modules/nixos/services/monitoring_sync.nix
+++ b/modules/nixos/services/monitoring_sync.nix
@@ -12,6 +12,11 @@
     text = builtins.toJSON cfg.monitors;
   };
 
+  maintenancesJson = pkgs.writeTextFile {
+    name = "homelab-maintenance-windows.json";
+    text = builtins.toJSON cfg.maintenanceWindows;
+  };
+
   pythonEnv = pkgs.python3.withPackages (ps: [
     ps.uptime-kuma-api
     ps.requests
@@ -24,8 +29,11 @@
         cache_dir="/var/lib/homelab/monitoring"
         cache_file="$cache_dir/records.json"
         tmp_cache="$cache_dir/records.json.tmp"
+        maint_cache_file="$cache_dir/maintenance.json"
+        tmp_maint_cache="$cache_dir/maintenance.json.tmp"
         env_file=${lib.escapeShellArg config.sops.secrets."uptime-kuma/env".path}
         desired_file=${lib.escapeShellArg monitorsJson}
+        maintenances_file=${lib.escapeShellArg maintenancesJson}
         kuma_url=${lib.escapeShellArg cfg.kumaUrl}
 
         mkdir -p "$cache_dir"
@@ -60,8 +68,11 @@
         export KUMA_USER="$kuma_user"
         export KUMA_PASS="$kuma_pass"
         export DESIRED_FILE="$desired_file"
+        export MAINTENANCES_FILE="$maintenances_file"
         export CACHE_FILE="$cache_file"
         export TMP_CACHE="$tmp_cache"
+        export MAINT_CACHE_FILE="$maint_cache_file"
+        export TMP_MAINT_CACHE="$tmp_maint_cache"
 
         max_wait_seconds=60
         waited=0
@@ -79,18 +90,24 @@
     import os
     import time
     import socketio
-    from uptime_kuma_api import UptimeKumaApi, MonitorType, AuthMethod
+    from uptime_kuma_api import UptimeKumaApi, MonitorType, AuthMethod, MaintenanceStrategy
     from uptime_kuma_api.exceptions import UptimeKumaException
 
     kuma_url = os.environ["KUMA_URL"]
     kuma_user = os.environ["KUMA_USER"]
     kuma_pass = os.environ["KUMA_PASS"]
     desired_path = os.environ["DESIRED_FILE"]
+    maintenances_path = os.environ["MAINTENANCES_FILE"]
     cache_path = os.environ["CACHE_FILE"]
     tmp_path = os.environ["TMP_CACHE"]
+    maint_cache_path = os.environ["MAINT_CACHE_FILE"]
+    tmp_maint_cache_path = os.environ["TMP_MAINT_CACHE"]
 
     with open(desired_path, "r", encoding="utf-8") as fh:
         desired = json.load(fh)
+
+    with open(maintenances_path, "r", encoding="utf-8") as fh:
+        desired_maintenances = json.load(fh)
 
     try:
         with open(cache_path, "r", encoding="utf-8") as fh:
@@ -98,8 +115,19 @@
     except FileNotFoundError:
         cache = {}
 
-    def sync_once() -> dict:
+    try:
+        with open(maint_cache_path, "r", encoding="utf-8") as fh:
+            maint_cache = json.load(fh)
+    except FileNotFoundError:
+        maint_cache = {}
+
+    def parse_hhmm(value: str) -> dict:
+        h, m = value.split(":", 1)
+        return {"hours": int(h), "minutes": int(m)}
+
+    def sync_once() -> tuple:
         updated = {}
+        updated_maint = {}
         with UptimeKumaApi(kuma_url, timeout=30) as api:
             api.login(username=kuma_user, password=kuma_pass)
             monitors = api.get_monitors()
@@ -133,6 +161,9 @@
                 if entry.get("basicAuthPassEnv"):
                     basic_auth_pass = os.environ.get(entry["basicAuthPassEnv"], basic_auth_pass)
                 interval = entry.get("interval", 60)
+                maxretries = int(entry.get("maxretries", 10))
+                retry_interval = int(entry.get("retryInterval", 60))
+                resend_interval = int(entry.get("resendInterval", 240))
 
                 if mon_type == "json-query":
                     kuma_type = MonitorType.JSON_QUERY
@@ -148,6 +179,9 @@
                     notificationIDList=notification_ids,
                     maxredirects=10,
                     interval=interval,
+                    maxretries=maxretries,
+                    retryInterval=retry_interval,
+                    resendInterval=resend_interval,
                 )
                 if headers_json:
                     common_kwargs["headers"] = headers_json
@@ -191,6 +225,9 @@
                         or existing_codes != desired_codes
                         or existing_notifications != desired_notifications
                         or existing.get("interval") != interval
+                        or int(existing.get("maxretries") or 0) != maxretries
+                        or int(existing.get("retryInterval") or 0) != retry_interval
+                        or int(existing.get("resendInterval") or 0) != resend_interval
                         or (json_path and existing.get("jsonPath") != json_path)
                         or (expected_value and str(existing.get("expectedValue", "")) != expected_value)
                         or (basic_auth_user and str(existing.get("authMethod", "")) != str(AuthMethod.HTTP_BASIC))
@@ -216,15 +253,98 @@
                 monitor_id = resp.get("monitorID") or resp.get("monitorId")
                 updated[url] = {"name": name, "url": url, "monitorId": monitor_id}
 
-        return updated
+            # ---------------------------------------------------------------
+            # Maintenance windows
+            # ---------------------------------------------------------------
+            if desired_maintenances:
+                # Refresh monitor list in case we just added new ones.
+                all_monitors = api.get_monitors()
+                name_to_id = {m.get("name"): m.get("id") for m in all_monitors if m.get("name")}
+                all_ids = [m.get("id") for m in all_monitors if m.get("id") is not None]
+
+                existing_maint = api.get_maintenances() or []
+                existing_by_title = {m.get("title"): m for m in existing_maint if m.get("title")}
+
+                for entry in desired_maintenances:
+                    title = entry["title"]
+                    description = entry.get("description", "")
+                    active = bool(entry.get("active", True))
+                    timezone = entry.get("timezone", "Australia/Perth")
+                    strategy_str = entry.get("strategy", "recurring-interval")
+                    interval_day = int(entry.get("intervalDay", 1))
+                    start_time = entry.get("startTime", "00:00")
+                    end_time = entry.get("endTime", "01:00")
+                    start_date = entry.get("startDate", "2026-01-01 00:00:00")
+                    end_date = entry.get("endDate", "2099-12-31 23:59:59")
+                    applies_all = bool(entry.get("appliesToAllMonitors", True))
+                    monitor_names = entry.get("monitorNames", []) or []
+
+                    if strategy_str != "recurring-interval":
+                        raise UptimeKumaException(
+                            f"maintenance window {title!r}: only recurring-interval strategy is supported"
+                        )
+
+                    time_range = [parse_hhmm(start_time), parse_hhmm(end_time)]
+                    date_range = [start_date, end_date]
+
+                    maint_kwargs = dict(
+                        title=title,
+                        description=description,
+                        strategy=MaintenanceStrategy.RECURRING_INTERVAL,
+                        active=active,
+                        intervalDay=interval_day,
+                        dateRange=date_range,
+                        timeRange=time_range,
+                        timezone=timezone,
+                        weekdays=[],
+                        daysOfMonth=[],
+                    )
+
+                    existing = existing_by_title.get(title)
+                    if existing:
+                        maint_id = existing.get("id")
+                        # Always edit — cheap and guarantees convergence.
+                        api.edit_maintenance(maint_id, **maint_kwargs)
+                    else:
+                        resp = api.add_maintenance(**maint_kwargs)
+                        maint_id = resp.get("maintenanceID") or resp.get("maintenanceId") or resp.get("id")
+                        if maint_id is None:
+                            # Re-fetch to discover the id.
+                            for m in api.get_maintenances() or []:
+                                if m.get("title") == title:
+                                    maint_id = m.get("id")
+                                    break
+                        if maint_id is None:
+                            raise UptimeKumaException(
+                                f"maintenance window {title!r}: could not determine id after create"
+                            )
+
+                    # Attach monitors (replaces the existing attachment set).
+                    if applies_all:
+                        attach_ids = list(all_ids)
+                    else:
+                        attach_ids = [name_to_id[n] for n in monitor_names if n in name_to_id]
+                    monitor_payload = [{"id": mid} for mid in attach_ids if mid is not None]
+                    api.add_monitor_maintenance(maint_id, monitor_payload)
+
+                    updated_maint[title] = {
+                        "title": title,
+                        "maintenanceId": maint_id,
+                        "monitorCount": len(monitor_payload),
+                    }
+
+        return updated, updated_maint
 
     last_error = None
     for attempt in range(3):
         try:
-            result = sync_once()
+            monitor_result, maint_result = sync_once()
             with open(tmp_path, "w", encoding="utf-8") as fh:
-                json.dump(result, fh, indent=2, sort_keys=True)
+                json.dump(monitor_result, fh, indent=2, sort_keys=True)
             os.replace(tmp_path, cache_path)
+            with open(tmp_maint_cache_path, "w", encoding="utf-8") as fh:
+                json.dump(maint_result, fh, indent=2, sort_keys=True)
+            os.replace(tmp_maint_cache_path, maint_cache_path)
             last_error = None
             break
         except (socketio.exceptions.TimeoutError, socketio.exceptions.BadNamespaceError, UptimeKumaException) as exc:
@@ -338,10 +458,109 @@ in {
             default = 60;
             description = "Check interval in seconds.";
           };
+          maxretries = lib.mkOption {
+            type = lib.types.int;
+            default = 10;
+            description = ''
+              Number of consecutive failed checks before the monitor is marked
+              DOWN and a notification fires. At the default interval of 60s,
+              maxretries=10 means a blip needs ~10 minutes of continuous
+              failure before alerting — this suppresses the nightly rebuild
+              noise without hiding real outages.
+            '';
+          };
+          retryInterval = lib.mkOption {
+            type = lib.types.int;
+            default = 60;
+            description = "Seconds between retries after a failed check.";
+          };
+          resendInterval = lib.mkOption {
+            type = lib.types.int;
+            default = 240;
+            description = ''
+              Number of heartbeats between re-notifications while a monitor is
+              still DOWN. At interval=60s, 240 ≈ 4 hours — persistent outages
+              re-page so you notice if you missed the first ping.
+            '';
+          };
         };
       });
       default = [];
       description = "List of monitors to ensure in Uptime Kuma.";
+    };
+
+    maintenanceWindows = lib.mkOption {
+      type = lib.types.listOf (lib.types.submodule {
+        options = {
+          title = lib.mkOption {
+            type = lib.types.str;
+            description = "Unique title — used as the key to find/update windows in Kuma.";
+          };
+          description = lib.mkOption {
+            type = lib.types.str;
+            default = "";
+            description = "Human description shown in the Kuma UI.";
+          };
+          active = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Whether the window is active.";
+          };
+          timezone = lib.mkOption {
+            type = lib.types.str;
+            default = "Australia/Perth";
+            description = "Timezone the startTime/endTime are interpreted in.";
+          };
+          strategy = lib.mkOption {
+            type = lib.types.enum ["recurring-interval"];
+            default = "recurring-interval";
+            description = "Only recurring-interval is currently supported.";
+          };
+          intervalDay = lib.mkOption {
+            type = lib.types.int;
+            default = 1;
+            description = "Run the window every N days.";
+          };
+          startTime = lib.mkOption {
+            type = lib.types.str;
+            description = "Start time of the daily window, format HH:MM.";
+          };
+          endTime = lib.mkOption {
+            type = lib.types.str;
+            description = "End time of the daily window, format HH:MM.";
+          };
+          startDate = lib.mkOption {
+            type = lib.types.str;
+            default = "2026-01-01 00:00:00";
+            description = "Date from which the recurring window applies.";
+          };
+          endDate = lib.mkOption {
+            type = lib.types.str;
+            default = "2099-12-31 23:59:59";
+            description = "Date after which the recurring window no longer applies.";
+          };
+          appliesToAllMonitors = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = ''
+              If true, attach every monitor known to Kuma to this window.
+              If false, only attach monitors listed in `monitorNames`.
+            '';
+          };
+          monitorNames = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [];
+            description = "Monitor names (match `homelab.monitoring.monitors.*.name`). Only used when appliesToAllMonitors = false.";
+          };
+        };
+      });
+      default = [];
+      description = ''
+        Declarative Uptime Kuma maintenance windows. Use these to silence
+        expected fleet-wide noise (e.g. nightly rebuilds) so real alerts
+        aren't drowned out. Define each window exactly once — on the host
+        that runs Uptime Kuma — to avoid cross-host races.
+      '';
     };
   };
 

--- a/modules/nixos/services/uptime-kuma.nix
+++ b/modules/nixos/services/uptime-kuma.nix
@@ -58,6 +58,33 @@ in {
           url = "https://status.ablz.au/";
         }
       ];
+
+      # Fleet-wide maintenance window covering nightly auto-updates.
+      #
+      # Why this exists: `homelab.update` runs on every host between 01:00
+      # and 04:00 AWST with a 60-minute randomized delay, plus GC and kernel
+      # reboots. Before this window existed, every rebuild blipped all
+      # ~26 monitors and Gotify-paged for every DOWN→UP transition, training
+      # us to ignore alerts — which is how we missed immich being down for
+      # three days. See `modules/nixos/autoupdate/update.nix` for the schedule.
+      #
+      # The window covers 00:45 → 05:30 AWST, which is the earliest possible
+      # rebuild start through the latest possible kernel reboot completion.
+      # It deliberately re-opens alerting at 05:30 so that if maintenance
+      # itself breaks something, we still get paged during normal hours.
+      #
+      # Defined here (and only here) because this is the host that runs
+      # Uptime Kuma — keeping the declaration single-homed avoids cross-host
+      # races in the sync service.
+      monitoring.maintenanceWindows = [
+        {
+          title = "nightly-rebuilds";
+          description = "Silence alerts during fleet auto-update window (homelab.update).";
+          startTime = "00:45";
+          endTime = "05:30";
+          timezone = "Australia/Perth";
+        }
+      ];
     };
   };
 }


### PR DESCRIPTION
## Summary

Nightly auto-updates were blipping every monitor and training us to ignore Gotify pings — which is how we missed immich being down for three days. This fix attacks alert fatigue at the source.

- **Tuned monitor defaults** — `maxretries=10`, `retryInterval=60`, `resendInterval=240`. At the default 60s check interval that means ~10min grace before DOWN and ~4h re-page cadence. Persistent outages stay visible; rebuild blips stay silent.
- **Declarative maintenance windows** — new `homelab.monitoring.maintenanceWindows` option, synced via `uptime-kuma-api` (`add_maintenance` / `edit_maintenance` / `add_monitor_maintenance`). Supports `recurring-interval` strategy with `appliesToAllMonitors` for fleet-wide suppression.
- **Nightly-rebuilds window 00:45–05:30 AWST** — covers the full `homelab.update` schedule: 01:00 default + 60min randomized delay, doc1's 03:00 and doc2's 04:00 slots, plus kernel reboot tail. Declared only on the uptime-kuma host (doc2) to avoid cross-host sync races. Re-opens alerting at 05:30 so broken-by-maintenance still pages during normal hours.
- **Docs** — `.claude/rules/nixos-service-modules.md` now documents the noise-discipline defaults and maintenance window pattern.

## Why this shape

- **Why 10 retries, not 3** — user preference: "I don't need instant reporting". 10min grace is wide enough to absorb any container restart during rolling deploys.
- **Why 4h re-page, not hourly** — user preference again: sparse re-pages are more likely to be read than spammy ones.
- **Why define the window only on doc2** — the sync service runs on every host that has monitors, so defining windows in a shared profile would cause multiple hosts to race on creating the same Kuma maintenance. Keeping it single-homed on the Kuma host is both simpler and safer.
- **Why `add_monitor_maintenance` with the full monitor list every run** — Kuma's attach API replaces the list, so this converges idempotently without needing a delete path.

## Test plan

- [ ] `nix flake check` (locally OOM'd on this laptop — run on a bigger box)
- [ ] `nixos-rebuild build --flake .#doc2` builds cleanly
- [ ] `nixos-rebuild build --flake .#proxmox-vm` and one other host (to confirm the new options don't break hosts that register monitors but not maintenance windows)
- [ ] Deploy to doc2 and tail `journalctl -u homelab-monitoring-sync` — expect it to edit all ~26 monitors (setting maxretries/retryInterval/resendInterval) and create the `nightly-rebuilds` maintenance window
- [ ] In the Kuma UI, confirm the window shows up under Settings → Maintenance with recurring-interval 00:45–05:30 AWST and all monitors attached
- [ ] Watch tonight's rebuild window (01:00–05:30 AWST) and confirm Gotify stays quiet
- [ ] Manually stop one non-critical service outside the window and confirm it still pages after ~10 min

## Rollback

Revert the commit. The sync will leave the maintenance window in Kuma on next run (no delete path yet) — manually delete it via the Kuma UI if needed. Monitor retry settings will revert to Kuma defaults on next sync.