### PR TITLE
feat(flake): fetch vinsight-mcp over git+ssh (Phase 2 of #210)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -916,15 +916,15 @@
       "locked": {
         "lastModified": 1771901753,
         "narHash": "sha256-F4wQ293vjwh2usqelMWBmVXIV2nuzK5rw0nUKyETiLM=",
-        "owner": "abl030",
-        "repo": "vinsight-mcp",
+        "ref": "refs/heads/master",
         "rev": "f3d1132db90b4da4be406c177cf2741f29a6c414",
-        "type": "github"
+        "revCount": 70,
+        "type": "git",
+        "url": "ssh://git@github.com/abl030/vinsight-mcp"
       },
       "original": {
-        "owner": "abl030",
-        "repo": "vinsight-mcp",
-        "type": "github"
+        "type": "git",
+        "url": "ssh://git@github.com/abl030/vinsight-mcp"
       }
     },
     "yt-dlp-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -177,9 +177,13 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # Vinsight MCP - MCP server for Vinsight winery API
+    # Vinsight MCP - MCP server for Vinsight winery API.
+    # Private repo: fetched over SSH with the fleet identity deploy key
+    # (hosts.nix:masterKeys) so the rest of the flake stays resilient when
+    # the GitHub PAT rotates. See issue #210 and
+    # docs/wiki/infrastructure/github-pat-and-private-inputs.md.
     vinsight-mcp = {
-      url = "github:abl030/vinsight-mcp";
+      url = "git+ssh://git@github.com/abl030/vinsight-mcp";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
## Summary

- Switch `vinsight-mcp` flake input from `github:abl030/vinsight-mcp` (HTTPS + PAT) to `git+ssh://git@github.com/abl030/vinsight-mcp` (SSH deploy key).
- Completes the fix for #210: after this merges, PAT rotation can no longer knock out fleet upgrades because private-input fetches no longer touch the PAT.

## Gating — do NOT merge until Phase 1 has rolled out fleet-wide

Phase 1 (commit 6c783c6 on master) ships:
- `/root/.ssh/id_ed25519` mirror for nix's git+ssh fetches
- GitHub ed25519 host key pinned in known_hosts
- PAT validation in activation + ExecStartPre so stale PATs degrade gracefully

Every host needs Phase 1 active before this can safely merge. After one auto-upgrade cycle under Phase 1 (~24h from 2026-04-17), every NixOS host should have the root key in place and be ready for Phase 2.

## Deploy key

Already added to `github.com/abl030/vinsight-mcp` via `gh api` (fleet identity pubkey, read-only, title "fleet-identity (ssh_key_abl030) - read only").

## Test plan

- [ ] Confirm Phase 1 has activated on every fleet host (`ls /root/.ssh/id_ed25519` returns a file on doc1, doc2, igpu, epimetheus, framework, dev, cache).
- [ ] Merge this PR.
- [ ] Trigger a manual `nixos-rebuild switch --flake github:abl030/nixosconfig#<host> --refresh` on one host (start with doc1 since it runs rolling-flake-update and seeds the cache).
- [ ] Watch for successful fetch of `vinsight-mcp` via `git+ssh`.
- [ ] Confirm doc1 cache has the new `vinsight-mcp` FOD so other hosts can pull from cache if needed.
- [ ] Observe the 01:00 fleet-wide auto-upgrade the next morning; no Gotify failures.

See `docs/wiki/infrastructure/github-pat-and-private-inputs.md` (shipped in Phase 1) for the full rationale and recovery flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)