### PR TITLE
cratedigger: rename wrapper soularr → cratedigger

### DIFF
--- a/.claude/prompts/cratedigger-vbr-v0.md
+++ b/.claude/prompts/cratedigger-vbr-v0.md
@@ -1,23 +1,23 @@
-# Implement VBR V0 Support in Soularr (Red/Green TDD)
+# Implement VBR V0 Support in Cratedigger (Red/Green TDD)
 
 ## Issue
-https://github.com/abl030/soularr/issues/1
+https://github.com/abl030/cratedigger/issues/1
 
 ## Objective
-Add `mp3 v0` and `mp3 v2` support to soularr's `allowed_filetypes` config so VBR MP3 files can be specifically targeted instead of falling through to the catch-all bare `mp3` entry.
+Add `mp3 v0` and `mp3 v2` support to cratedigger's `allowed_filetypes` config so VBR MP3 files can be specifically targeted instead of falling through to the catch-all bare `mp3` entry.
 
 ## Repos & Files
 
-**Soularr fork** (where the code change goes):
-- Local clone: `~/soularr/` (remote: `github:abl030/soularr`)
-- Main file: `~/soularr/soularr.py`
+**Cratedigger fork** (where the code change goes):
+- Local clone: `~/soularr/` (remote: `github:abl030/cratedigger`)
+- Main file: `~/soularr/cratedigger.py`
 - Key function: `verify_filetype()` at ~line 280
-- No existing tests — you'll create `~/soularr/test_soularr.py`
+- No existing tests — you'll create `~/soularr/test_cratedigger.py`
 
 **nixosconfig** (where deployment config lives):
-- Soularr nix module: `modules/nixos/services/soularr.nix`
-- Flake input `soularr-src` pins the fork (line in `flake.nix`)
-- Config template with `allowed_filetypes` is in `soularr.nix` ~line 129
+- Cratedigger nix module: `modules/nixos/services/cratedigger.nix`
+- Flake input `cratedigger-src` pins the fork (line in `flake.nix`)
+- Config template with `allowed_filetypes` is in `cratedigger.nix` ~line 129
 - Currently set to: `flac 24/192,flac 24/96,flac 24/48,flac 16/44.1,flac,alac,mp3 320,mp3`
 
 ## How `verify_filetype()` Works Today
@@ -51,7 +51,7 @@ The `file` dict from slskd API contains:
 
 ### Phase 1: RED — Write Failing Tests
 
-Create `~/soularr/test_soularr.py` with pytest. Test `verify_filetype()` in isolation — it's a pure function, no mocking needed.
+Create `~/soularr/test_cratedigger.py` with pytest. Test `verify_filetype()` in isolation — it's a pure function, no mocking needed.
 
 **Test cases to write:**
 
@@ -135,14 +135,14 @@ def test_mp3_v0_cbr_with_vbr_flag_false():
     assert verify_filetype(file, "mp3 v0") == False
 ```
 
-**Run tests**: `cd ~/soularr && python -m pytest test_soularr.py -v`
+**Run tests**: `cd ~/soularr && python -m pytest test_cratedigger.py -v`
 (You may need `nix-shell -p python3Packages.pytest` or similar)
 
 Confirm the VBR tests fail. Existing tests should pass.
 
 ### Phase 2: GREEN — Implement
 
-Modify `verify_filetype()` in `~/soularr/soularr.py` to handle `v0` and `v2` as special attribute values.
+Modify `verify_filetype()` in `~/soularr/cratedigger.py` to handle `v0` and `v2` as special attribute values.
 
 **VBR V0 spec** (LAME -V 0): average bitrate typically 220-260kbps, targets ~245kbps
 **VBR V2 spec** (LAME -V 2): average bitrate typically 170-210kbps, targets ~190kbps
@@ -175,10 +175,10 @@ Run tests again. All should pass (green).
 
 ### Phase 3: Deploy & Verify on doc2
 
-1. **Commit to soularr fork**:
+1. **Commit to cratedigger fork**:
    ```bash
    cd ~/soularr
-   git add soularr.py test_soularr.py
+   git add cratedigger.py test_cratedigger.py
    git commit -m "feat: add VBR V0/V2 support in allowed_filetypes"
    git push
    ```
@@ -186,10 +186,10 @@ Run tests again. All should pass (green).
 2. **Update flake input in nixosconfig**:
    ```bash
    cd ~/nixosconfig
-   nix flake update soularr-src
+   nix flake update cratedigger-src
    ```
 
-3. **Update `allowed_filetypes` in soularr.nix** to use `mp3 v0` instead of bare `mp3`:
+3. **Update `allowed_filetypes` in cratedigger.nix** to use `mp3 v0` instead of bare `mp3`:
    Change: `flac 24/192,flac 24/96,flac 24/48,flac 16/44.1,flac,alac,mp3 320,mp3`
    To: `flac 24/192,flac 24/96,flac 24/48,flac 16/44.1,flac,alac,mp3 v0,mp3 320`
 
@@ -198,7 +198,7 @@ Run tests again. All should pass (green).
 5. **Deploy to doc2**:
    ```bash
    cd ~/nixosconfig
-   git add -A && git commit -m "feat(soularr): update fork with VBR V0 support, restrict allowed filetypes"
+   git add -A && git commit -m "feat(cratedigger): update fork with VBR V0 support, restrict allowed filetypes"
    git push
    ssh doc2 "cd ~/nixosconfig && git pull && sudo nixos-rebuild switch --flake .#doc2 --refresh"
    ```
@@ -206,10 +206,10 @@ Run tests again. All should pass (green).
 6. **Verify on doc2**:
    ```bash
    # Check the generated config
-   ssh doc2 "sudo cat /var/lib/soularr/config.ini | grep allowed_filetypes"
+   ssh doc2 "sudo cat /var/lib/cratedigger/config.ini | grep allowed_filetypes"
 
-   # Trigger a soularr run and watch
-   ssh doc2 "sudo systemctl start soularr && journalctl -u soularr -f"
+   # Trigger a cratedigger run and watch
+   ssh doc2 "sudo systemctl start cratedigger && journalctl -u cratedigger -f"
 
    # Look for VBR matches vs rejections in logs
    ```
@@ -218,7 +218,7 @@ Run tests again. All should pass (green).
 
 If you want to verify against real slskd data, SSH to doc2 and query the slskd API for a recent search result to see what fields are actually present:
 ```bash
-ssh doc2 'SLSKD_KEY=$(sudo grep SOULARR_SLSKD_API_KEY /var/lib/soularr/config.ini | cut -d= -f2 | tr -d " "); curl -s "http://localhost:5030/api/v0/searches" -H "X-API-Key: $SLSKD_KEY" | python3 -m json.tool | head -100'
+ssh doc2 'SLSKD_KEY=$(sudo grep SOULARR_SLSKD_API_KEY /var/lib/cratedigger/config.ini | cut -d= -f2 | tr -d " "); curl -s "http://localhost:5030/api/v0/searches" -H "X-API-Key: $SLSKD_KEY" | python3 -m json.tool | head -100'
 ```
 
 This tells you whether `isVariableBitRate` exists in the response. Adjust the implementation accordingly.
@@ -235,4 +235,4 @@ This tells you whether `isVariableBitRate` exists in the response. Adjust the im
 
 - Run the existing tests to make sure nothing breaks
 - The `get_existing_quality_tier()` function (~line 824) also maps Lidarr quality names to `allowed_filetypes` — check if it needs updating for VBR
-- Close the GitHub issue when done: `gh issue close 1 --repo abl030/soularr`
+- Close the GitHub issue when done: `gh issue close 1 --repo abl030/cratedigger`

--- a/.claude/rules/nixos-service-modules.md
+++ b/.claude/rules/nixos-service-modules.md
@@ -57,7 +57,7 @@ services.<service>.database = {
 ```
 
 **Existing hostNums** (check before assigning):
-- 1=atuin, 2=immich, 3=paperless, 4=mealie, 5=soularr, 6=discogs, 7=jellystat
+- 1=atuin, 2=immich, 3=paperless, 4=mealie, 5=cratedigger, 6=discogs, 7=jellystat
 
 ### CRITICAL: restartTriggers for container dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,7 +254,7 @@ See `vms/proxmox-ops.sh` (VM ops) and `secrets/.sops.yaml` (secrets). Longer-for
 - **caddy**: Server/container (Home Manager only)
 - **wsl**: WSL instance (full NixOS with NixOS-WSL)
 - **proxmox-vm** (doc1): Main services VM on Proxmox (VMID 104, imported)
-- **doc2**: Secondary services VM on Proxmox (IPs: 192.168.1.35/ens18, 192.168.1.36/ens19). Hosts most homelab services: immich, seerr/overseerr, soularr, lidarr, musicbrainz, paperless, mealie, kopia, uptime-kuma, etc. All state on virtiofs (`device = "containers"` from prom ZFS). Auto-updates with reboot.
+- **doc2**: Secondary services VM on Proxmox (IPs: 192.168.1.35/ens18, 192.168.1.36/ens19). Hosts most homelab services: immich, seerr/overseerr, cratedigger, lidarr, musicbrainz, paperless, mealie, kopia, uptime-kuma, etc. All state on virtiofs (`device = "containers"` from prom ZFS). Auto-updates with reboot.
 - **igpu**: Media transcoding with AMD iGPU passthrough (VMID 109, imported)
 - **dev**: Development VM (VMID 110, managed)
 

--- a/docs/beads-archive.md
+++ b/docs/beads-archive.md
@@ -17,7 +17,7 @@ Track current rootless Podman compose operating model, accepted residual risks, 
 
 ### Notes
 
-2026-02-24 incident: music stack went down after a compose file change (slskd/soularr commented out) triggered a service restart. compose stop left containers in Exited state; compose up then failed because the old network-holder pod still had dependent containers registered against it, so docker-compose couldn't recreate the pod. The ExecStartPre recreate-if-label-mismatch script only removed containers with a PODMAN_SYSTEMD_UNIT label mismatch — correctly-labelled Exited containers were untouched. Fix (untested): extended the script to also rm -f --depend all exited/created/dead containers for the project before compose up, giving it a clean slate. All persistent state is in volumes so this is safe.
+2026-02-24 incident: music stack went down after a compose file change (slskd/cratedigger commented out) triggered a service restart. compose stop left containers in Exited state; compose up then failed because the old network-holder pod still had dependent containers registered against it, so docker-compose couldn't recreate the pod. The ExecStartPre recreate-if-label-mismatch script only removed containers with a PODMAN_SYSTEMD_UNIT label mismatch — correctly-labelled Exited containers were untouched. Fix (untested): extended the script to also rm -f --depend all exited/created/dead containers for the project before compose up, giving it a clean slate. All persistent state is in volumes so this is safe.
 
 ---
 
@@ -4178,7 +4178,7 @@ UNICODE HYPHEN BUG: Lidarr's release parser splits on ASCII hyphen (U+002D) but 
 
 ---
 
-## nixosconfig-ixw — Soularr Xavier matching diagnosis: peer availability + track count mismatch
+## nixosconfig-ixw — Cratedigger Xavier matching diagnosis: peer availability + track count mismatch
 
 - **Status:** open
 - **Type:** task
@@ -4188,12 +4188,12 @@ UNICODE HYPHEN BUG: Lidarr's release parser splits on ASCII hyphen (U+002D) but 
 ### Description
 
 ## Problem
-Soularr repeatedly fails to download MP3 320 of xaviersobased - Xavier despite correct matches existing on soulseek.
+Cratedigger repeatedly fails to download MP3 320 of xaviersobased - Xavier despite correct matches existing on soulseek.
 
 ## Root Causes Found (3 issues, all fixed)
 
 ### Issue 1: No user fallback on download failure (FIXED)
-When downloads from the matched user all error out (e.g. claire419 — user is Away, transfers rejected), soularr gave up on the entire album. Never tried the next matching user.
+When downloads from the matched user all error out (e.g. claire419 — user is Away, transfers rejected), cratedigger gave up on the entire album. Never tried the next matching user.
 
 ### Issue 2: Search cache filetype narrowing excludes valid users (FIXED)
 verify_filetype("mp3 320") requires bitRate=320 in search metadata. Many soulseek clients don't report bitrate → files cached under generic "mp3" only. Combined with cutoff_unmet logic restricting to ["mp3 320"], most valid users were invisible.
@@ -4204,7 +4204,7 @@ Diagnostic evidence: out of 16 search result users, only 3 had "mp3 320" in cach
 BonteKraai had 20 correct MP3 320 tracks but scored 0.5-0.73 due to filename format mismatch. The check_ratio truncation works for standard "01. artist - title.mp3" but not all naming conventions. Consider reducing to 0.6.
 
 ## Changes Made
-File: /tmp/soularr/soularr.py (volume-mounted into soularr container on doc1)
+File: /tmp/cratedigger/cratedigger.py (volume-mounted into cratedigger container on doc1)
 
 1. skip_users parameter threading through try_enqueue → try_multi_enqueue → find_download
 2. monitor_downloads.delete_album() tries fallback before failing (max 3 users)
@@ -4221,16 +4221,16 @@ File: /tmp/soularr/soularr.py (volume-mounted into soularr container on doc1)
 ## Patch Plumbing
 
 ### Current patch (cutoff_unmet quality skip + user fallback + filetype broadening)
-- Source: /tmp/soularr/soularr.py (git clone of mrusse/soularr + local edits)
-- Deployed via: scp to doc1:/mnt/docker/music/soularr/soularr.py
+- Source: /tmp/cratedigger/cratedigger.py (git clone of mrusse/soularr + local edits)
+- Deployed via: scp to doc1:/mnt/docker/music/cratedigger/cratedigger.py
 - Volume mount in stacks/music/docker-compose.yml line 97:
-  ${DATA_ROOT}/music/soularr/soularr.py:/app/soularr.py:ro
+  ${DATA_ROOT}/music/cratedigger/cratedigger.py:/app/cratedigger.py:ro
 - Container restart picks up changes (no nix rebuild needed for py changes)
 
 ### Deployment workflow
-1. Edit /tmp/soularr/soularr.py on WSL
-2. scp to doc1:/mnt/docker/music/soularr/soularr.py
-3. ssh doc1 "podman restart soularr" (or systemctl restart music.service)
+1. Edit /tmp/cratedigger/cratedigger.py on WSL
+2. scp to doc1:/mnt/docker/music/cratedigger/cratedigger.py
+3. ssh doc1 "podman restart cratedigger" (or systemctl restart music.service)
 
 ## Implemented Fixes (2026-02-17)
 
@@ -4650,7 +4650,7 @@ Phase 4+5: MCP servers working and full pipeline validated.
 
 ---
 
-## nixosconfig-aw3 — Fresh Lidarr setup and soularr bridge configuration
+## nixosconfig-aw3 — Fresh Lidarr setup and cratedigger bridge configuration
 
 - **Status:** open
 - **Type:** task
@@ -4659,15 +4659,15 @@ Phase 4+5: MCP servers working and full pipeline validated.
 
 ### Description
 
-Phase 2+3: Configure Lidarr and wire up soularr.
+Phase 2+3: Configure Lidarr and wire up cratedigger.
 
 - Fresh Lidarr config at http://doc1:8686
 - Set root folder to /mnt/data/music/ai
 - Configure import settings (tagging, naming)
 - Grab API key from Settings → General
 - Update secrets/arr-mcp.env with Lidarr API key
-- Copy soularr config to doc1 with Lidarr API key
-- Test: add album to Lidarr wanted list, verify soularr picks it up
+- Copy cratedigger config to doc1 with Lidarr API key
+- Test: add album to Lidarr wanted list, verify cratedigger picks it up
 
 ---
 
@@ -4732,7 +4732,7 @@ BLOCKS:
 
 Enable Claude Code to fulfill requests like "get me this album" by searching Soulseek, downloading via slskd, tagging via Lidarr, and serving via Plex.
 
-Architecture: Option C (Hybrid) — Soularr daemon for bulk/background, direct MCP for immediate requests.
+Architecture: Option C (Hybrid) — Cratedigger daemon for bulk/background, direct MCP for immediate requests.
 Host: doc1 (proxmox-vm). Music library: /mnt/data/music/ai.
 Quality default: 320kbps MP3 (overridable per request).
 
@@ -4759,7 +4759,7 @@ Full plan originally in docs/music-automation-plan.md (moved here).
 | **Music library path** | `/mnt/data/music/ai` (new subfolder for AI-sourced) |
 | **Soulseek credentials** | Existing account, store in sops |
 | **Secrets storage** | sops-encrypted (consistent with repo pattern) |
-| **Architecture** | Option C: Hybrid (Soularr daemon + direct MCP for immediate) |
+| **Architecture** | Option C: Hybrid (Cratedigger daemon + direct MCP for immediate) |
 | **Default quality** | 320kbps MP3 (overridable per request) |
 | **Duplicate handling** | Skip and warn if exists in library |
 | **Plex scanning** | Auto-scan enabled (no action needed) |
@@ -4811,12 +4811,12 @@ Claude controls each step directly via MCP servers:
 **Pros**: Full control, can handle edge cases, immediate feedback
 **Cons**: More MCP servers to maintain, Claude orchestrates everything
 
-### Option B: Soularr Daemon (Most Hands-Off)
+### Option B: Cratedigger Daemon (Most Hands-Off)
 
-Claude only adds to Lidarr's wanted list; Soularr daemon handles the rest:
+Claude only adds to Lidarr's wanted list; Cratedigger daemon handles the rest:
 1. Add album to Lidarr wanted list via Lidarr MCP
-2. Soularr (daemon) monitors wanted list every 5 min
-3. Soularr searches slskd and triggers download
+2. Cratedigger (daemon) monitors wanted list every 5 min
+3. Cratedigger searches slskd and triggers download
 4. Lidarr auto-imports from download folder
 5. Plex auto-scans library
 
@@ -4825,7 +4825,7 @@ Claude only adds to Lidarr's wanted list; Soularr daemon handles the rest:
 
 ### Option C: Hybrid
 
-Claude can do both — use Soularr for bulk/background, direct MCP for immediate requests.
+Claude can do both — use Cratedigger for bulk/background, direct MCP for immediate requests.
 
 ---
 
@@ -4836,13 +4836,13 @@ Claude can do both — use Soularr for bulk/background, direct MCP for immediate
 | Service | Image | Purpose | Port |
 |---------|-------|---------|------|
 | slskd | `slskd/slskd` | Soulseek client with REST API | 5030 (web), 5031 (API) |
-| soularr | `mrusse/soularr` | Lidarr ↔ slskd bridge | None (daemon) |
+| cratedigger | `mrusse/soularr` | Lidarr ↔ slskd bridge | None (daemon) |
 
 ### Existing Services to Configure
 
 | Service | Current State | Changes Needed |
 |---------|---------------|----------------|
-| Lidarr | Deployed on doc1, unused | Fresh config: root folder `/mnt/data/music/ai`, Soularr as download bridge |
+| Lidarr | Deployed on doc1, unused | Fresh config: root folder `/mnt/data/music/ai`, Cratedigger as download bridge |
 | Plex | Working, auto-scan enabled | Add `/mnt/data/music/ai` to music library |
 
 ### MCP Servers to Add
@@ -4862,7 +4862,7 @@ Claude can do both — use Soularr for bulk/background, direct MCP for immediate
 | Item | File | Notes |
 |------|------|-------|
 | Docker compose for slskd | `stacks/music/docker-compose.yml` | Added slskd service with volumes, ports 5030/5031 |
-| Docker compose for soularr | `stacks/music/docker-compose.yml` | Daemon that bridges Lidarr wanted list → slskd |
+| Docker compose for cratedigger | `stacks/music/docker-compose.yml` | Daemon that bridges Lidarr wanted list → slskd |
 | Firewall ports | `stacks/music/docker-compose.nix` | Added 5030, 5031 to firewallPorts |
 | MCP wrapper: arr | `scripts/mcp-arr.sh` | Sources secrets, runs `npx -y mcp-arr-server` |
 | MCP wrapper: soulseek | `scripts/mcp-soulseek.sh` | Sources secrets, runs soulseek MCP |
@@ -4871,7 +4871,7 @@ Claude can do both — use Soularr for bulk/background, direct MCP for immediate
 | Secrets: arr-mcp.env | `secrets/arr-mcp.env` | sops-encrypted, has placeholder API key |
 | Secrets: soulseek-mcp.env | `secrets/soulseek-mcp.env` | sops-encrypted, has placeholder credentials |
 | Secrets: music.env | `secrets/music.env` | Updated with SOULSEEK_USERNAME/PASSWORD placeholders |
-| Soularr config template | `stacks/music/soularr/config.yaml` | Template config, needs Lidarr API key |
+| Cratedigger config template | `stacks/music/cratedigger/config.yaml` | Template config, needs Lidarr API key |
 | Quality gate | - | `check` passes |
 
 **Note**: The MCP module is defined but NOT enabled in any host config yet. Nothing will run until you explicitly enable it.
@@ -4913,16 +4913,16 @@ nixos-rebuild switch --flake .#proxmox-vm --target-host proxmox-vm
 sops secrets/arr-mcp.env
 # Change LIDARR_API_KEY to the key from Lidarr
 
-# 7. Copy soularr config to doc1 and update it
-scp stacks/music/soularr/config.yaml proxmox-vm:/mnt/data/music/soularr/
-ssh proxmox-vm 'nano /mnt/data/music/soularr/config.yaml'
+# 7. Copy cratedigger config to doc1 and update it
+scp stacks/music/cratedigger/config.yaml proxmox-vm:/mnt/data/music/cratedigger/
+ssh proxmox-vm 'nano /mnt/data/music/cratedigger/config.yaml'
 # Update the lidarr.api_key field with your Lidarr API key
 
 # 8. Restart the music stack on doc1
 ssh proxmox-vm 'systemctl --user restart podman-compose@music'
 
 # 9. Verify services are running
-ssh proxmox-vm 'podman ps | grep -E "slskd|soularr|lidarr"'
+ssh proxmox-vm 'podman ps | grep -E "slskd|cratedigger|lidarr"'
 
 # 10. Test slskd web UI
 #     Browse to http://doc1:5030
@@ -4938,7 +4938,7 @@ Once setup is complete:
 
 1. **Test Lidarr MCP**: Restart Claude Code, then ask "search for artist Lucinda Williams in Lidarr"
 2. **Test slskd connection**: Check http://doc1:5030 shows "Connected" to Soulseek
-3. **Test Soularr**: Add an album to Lidarr's wanted list, wait 5 min, check if Soularr triggers a search
+3. **Test Cratedigger**: Add an album to Lidarr's wanted list, wait 5 min, check if Cratedigger triggers a search
 4. **End-to-end**: Ask Claude "get me Whiskeytown Strangers Almanac" and watch it flow through
 
 ---
@@ -4965,7 +4965,7 @@ Once setup is complete:
 
 ### Phase 1: Infrastructure [CODE COMPLETE]
 - [x] Docker compose for slskd
-- [x] Docker compose for soularr
+- [x] Docker compose for cratedigger
 - [x] Firewall ports configured
 - [ ] Deploy to doc1
 - [ ] Configure Soulseek credentials (fill in sops placeholders)
@@ -4980,10 +4980,10 @@ Once setup is complete:
 - [ ] Test manual import of a downloaded album
 
 ### Phase 3: Bridge Setup [CODE COMPLETE]
-- [x] Soularr container added to docker-compose
-- [x] Soularr config template created
+- [x] Cratedigger container added to docker-compose
+- [x] Cratedigger config template created
 - [ ] Copy config to doc1 and add Lidarr API key
-- [ ] Test: add album to Lidarr, verify Soularr picks it up
+- [ ] Test: add album to Lidarr, verify Cratedigger picks it up
 
 ### Phase 4: MCP Integration [CODE COMPLETE]
 - [x] Add mcp-arr-server to .mcp.json
@@ -4998,7 +4998,7 @@ Once setup is complete:
 - [ ] Update CLAUDE.md with music automation workflow
 - [ ] Add Plex library path if not present
 - [ ] Optional: Gotify notifications on download complete
-- [ ] Optional: Quality filters in Soularr/slskd config
+- [ ] Optional: Quality filters in Cratedigger/slskd config
 
 ---
 
@@ -5058,13 +5058,13 @@ services:
       - "5031:5031"  # API
     restart: unless-stopped
 
-  soularr:
+  cratedigger:
     image: mrusse/soularr:latest
-    container_name: soularr
+    container_name: cratedigger
     environment:
       - ANTHROPIC_API_KEY=not_needed   # Only if using AI features
     volumes:
-      - ./soularr/config:/config
+      - ./cratedigger/config:/config
     depends_on:
       - slskd
     restart: unless-stopped
@@ -5088,7 +5088,7 @@ services:
 2. **Enable MCP module** in `hosts/proxmox-vm/configuration.nix` (see Remaining Manual Steps)
 3. **Deploy to doc1**: `nixos-rebuild switch --flake .#proxmox-vm --target-host proxmox-vm`
 4. **Fresh Lidarr setup** at http://doc1:8686, get API key
-5. **Update Lidarr API key** in `secrets/arr-mcp.env` and soularr config on doc1
+5. **Update Lidarr API key** in `secrets/arr-mcp.env` and cratedigger config on doc1
 6. **Test the pipeline** end-to-end
 
 ---
@@ -5097,8 +5097,8 @@ services:
 
 - [slskd GitHub](https://github.com/slskd/slskd)
 - [slskd API Docs](https://github.com/slskd/slskd/blob/master/docs/api.md)
-- [Soularr](https://soularr.net)
-- [Soularr GitHub](https://github.com/mrusse/soularr)
+- [Cratedigger](https://cratedigger.net)
+- [Cratedigger GitHub](https://github.com/mrusse/soularr)
 - [SoulseekMCP](https://glama.ai/mcp/servers/@jotraynor/SoulseekMCP)
 - [mcp-arr-server](https://www.npmjs.com/package/mcp-arr-server)
 - [Lidarr](https://lidarr.audio/)
@@ -5133,9 +5133,9 @@ fetchurl pre-built binary from GitHub Releases into nix/overlay.nix. Temporary u
 Before any deployment, review the full plan together:
 
 1. Audit existing code:
-   - stacks/music/docker-compose.yml (slskd + soularr services)
+   - stacks/music/docker-compose.yml (slskd + cratedigger services)
    - stacks/music/docker-compose.nix (firewall ports, nix integration)
-   - stacks/music/soularr/config.yaml (template config)
+   - stacks/music/cratedigger/config.yaml (template config)
    - scripts/mcp-arr.sh, scripts/mcp-soulseek.sh (MCP wrappers)
    - modules/nixos/services/mcp.nix (arr/soulseek options)
    - .mcp.json entries for arr + soulseek
@@ -5143,7 +5143,7 @@ Before any deployment, review the full plan together:
 2. Check infra state on doc1:
    - Is Lidarr already running? What state is it in?
    - Does /mnt/data/music/ exist? What's in it?
-   - Are slskd/soularr containers deployed or just defined?
+   - Are slskd/cratedigger containers deployed or just defined?
    - Network: can doc1 reach Soulseek network?
 
 3. Validate decisions still make sense:
@@ -5155,7 +5155,7 @@ Before any deployment, review the full plan together:
 
 ---
 
-## nixosconfig-k4e — Deploy slskd + soularr to doc1 and fill sops credentials
+## nixosconfig-k4e — Deploy slskd + cratedigger to doc1 and fill sops credentials
 
 - **Status:** closed
 - **Type:** task

--- a/docs/lidarr-migration-plan.md
+++ b/docs/lidarr-migration-plan.md
@@ -1,6 +1,6 @@
 # Lidarr Stack Migration: doc2 -> downloader
 
-**Goal**: Move Lidarr + slskd + soularr from doc2 (NixOS VM on Proxmox, NFS over network) to downloader (Ubuntu VM on Unraid, CIFS local to NAS) for dramatically better I/O performance.
+**Goal**: Move Lidarr + slskd + cratedigger from doc2 (NixOS VM on Proxmox, NFS over network) to downloader (Ubuntu VM on Unraid, CIFS local to NAS) for dramatically better I/O performance.
 
 **Temporary migration** — NixOS modules stay intact for future return.
 
@@ -10,7 +10,7 @@
 |---------|---------------------|--------------------------|
 | Lidarr | NixOS native, port 8686, 15GB data dir | Not installed |
 | slskd | NixOS native, port 5030/50300, VPN via ens19 | Not present |
-| soularr | NixOS native, 5min timer, from abl030/soularr fork | Not present |
+| cratedigger | NixOS native, 5min timer, from abl030/cratedigger fork | Not present |
 | Prowlarr | — | Already running, port 9696, already has Lidarr app connection |
 | Deluge | — | Already running, port 8112/58846 |
 | Music path | `/mnt/fuse/Media/Music/AI` (bindfs over NFS) | `/media/data/Media/Music/AI` (CIFS, local to NAS) |
@@ -25,7 +25,7 @@ Prowlarr (downloader:9696)  --syncs indexers-->  Lidarr (downloader:8686)
                                                     ^
                                                     |  pyarr API
                                                     v
-soularr (cron/systemd)  --slskd-api-->  slskd (downloader:5030)
+cratedigger (cron/systemd)  --slskd-api-->  slskd (downloader:5030)
                                           |
                                           |  Soulseek P2P (VPN at router level)
                                           v
@@ -46,14 +46,14 @@ soularr (cron/systemd)  --slskd-api-->  slskd (downloader:5030)
 
 ```bash
 # On doc2 — stop all three services
-ssh doc2 "sudo systemctl stop soularr.timer soularr.service"
+ssh doc2 "sudo systemctl stop cratedigger.timer cratedigger.service"
 ssh doc2 "sudo systemctl stop slskd.service"
 ssh doc2 "sudo systemctl stop lidarr.service"
 ```
 
 Verify nothing is running:
 ```bash
-ssh doc2 "systemctl status lidarr slskd soularr --no-pager"
+ssh doc2 "systemctl status lidarr slskd cratedigger --no-pager"
 ```
 
 ### Phase 2: Install Lidarr on downloader
@@ -245,35 +245,35 @@ ssh downloader "curl -s http://localhost:5030/api/v0/server | head -c 200"
 
 **VPN**: The downloader VM is routed through VPN at the router level (pfSense), so no per-service VPN config is needed. Soulseek traffic is automatically tunnelled.
 
-### Phase 4: Install soularr on downloader
+### Phase 4: Install cratedigger on downloader
 
 #### 4a. Install Python and dependencies
 ```bash
 ssh downloader << 'INSTALL'
 sudo apt-get update
 sudo apt-get install -y python3 python3-pip python3-venv
-sudo python3 -m venv /opt/soularr-venv
-sudo /opt/soularr-venv/bin/pip install requests music-tag pyarr slskd-api configparser
+sudo python3 -m venv /opt/cratedigger-venv
+sudo /opt/cratedigger-venv/bin/pip install requests music-tag pyarr slskd-api configparser
 # Clone the fork
-sudo git clone https://github.com/abl030/soularr.git /opt/soularr
+sudo git clone https://github.com/abl030/cratedigger.git /opt/cratedigger
 INSTALL
 ```
 
-#### 4b. Create soularr config
+#### 4b. Create cratedigger config
 ```bash
-# Decrypt soularr secrets
-sops -d secrets/soularr.env > /tmp/soularr-secrets.env
-source /tmp/soularr-secrets.env
+# Decrypt cratedigger secrets
+sops -d secrets/soularr.env > /tmp/cratedigger-secrets.env
+source /tmp/cratedigger-secrets.env
 
-ssh downloader "sudo mkdir -p /var/lib/soularr"
+ssh downloader "sudo mkdir -p /var/lib/cratedigger"
 
 # Need slskd API key too
 sops -d secrets/slskd.env > /tmp/slskd-secrets.env
 source /tmp/slskd-secrets.env
 
-ssh downloader "sudo tee /var/lib/soularr/config.ini << EOFCFG
+ssh downloader "sudo tee /var/lib/cratedigger/config.ini << EOFCFG
 [Lidarr]
-api_key = ${SOULARR_LIDARR_API_KEY}
+api_key = ${CRATEDIGGER_LIDARR_API_KEY}
 host_url = http://localhost:8686
 monitor_new_artists = false
 search_type = incrementing_page
@@ -300,30 +300,30 @@ allowed_filetypes = flac,mp3,ogg,m4a,wma,aac,opus,alac
 log_level = INFO
 EOFCFG"
 
-ssh downloader "sudo chown -R root:root /var/lib/soularr"
+ssh downloader "sudo chown -R root:root /var/lib/cratedigger"
 
-rm /tmp/soularr-secrets.env /tmp/slskd-secrets.env
+rm /tmp/cratedigger-secrets.env /tmp/slskd-secrets.env
 ```
 
-#### 4c. Create soularr systemd timer + service
+#### 4c. Create cratedigger systemd timer + service
 ```bash
-ssh downloader "sudo tee /etc/systemd/system/soularr.service << 'EOF'
+ssh downloader "sudo tee /etc/systemd/system/cratedigger.service << 'EOF'
 [Unit]
-Description=Soularr — Soulseek downloader for Lidarr
+Description=Cratedigger — Soulseek downloader for Lidarr
 After=lidarr.service slskd.service
 Wants=lidarr.service slskd.service
 
 [Service]
 Type=oneshot
-ExecStart=/opt/soularr-venv/bin/python /opt/soularr/soularr.py
-WorkingDirectory=/opt/soularr
-Environment=SOULARR_CONFIG=/var/lib/soularr/config.ini
+ExecStart=/opt/cratedigger-venv/bin/python /opt/cratedigger/cratedigger.py
+WorkingDirectory=/opt/cratedigger
+Environment=CRATEDIGGER_CONFIG=/var/lib/cratedigger/config.ini
 TimeoutStartSec=1800
 EOF"
 
-ssh downloader "sudo tee /etc/systemd/system/soularr.timer << 'EOF'
+ssh downloader "sudo tee /etc/systemd/system/cratedigger.timer << 'EOF'
 [Unit]
-Description=Run Soularr every 5 minutes
+Description=Run Cratedigger every 5 minutes
 
 [Timer]
 OnBootSec=2min
@@ -334,9 +334,9 @@ WantedBy=timers.target
 EOF"
 ```
 
-#### 4d. Start soularr
+#### 4d. Start cratedigger
 ```bash
-ssh downloader "sudo systemctl daemon-reload && sudo systemctl enable --now soularr.timer"
+ssh downloader "sudo systemctl daemon-reload && sudo systemctl enable --now cratedigger.timer"
 ```
 
 ### Phase 5: Update paths and integrations
@@ -446,8 +446,8 @@ curl -s http://192.168.1.4:8686/ping
 # 2. slskd is connected to Soulseek
 curl -s http://192.168.1.4:5030/api/v0/server | jq '.isConnected'
 
-# 3. Soularr timer is active
-ssh downloader "systemctl list-timers soularr.timer"
+# 3. Cratedigger timer is active
+ssh downloader "systemctl list-timers cratedigger.timer"
 
 # 4. Prowlarr syncs indexers to Lidarr
 # Check Lidarr Settings -> Indexers — should show synced indexers
@@ -471,7 +471,7 @@ Disable services in `hosts/doc2/configuration.nix` so they stay off after rebuil
 # In hosts/doc2/configuration.nix — disable but keep code
 homelab.services.lidarr.enable = false;      # or just comment out enable = true
 homelab.services.slskd.enable = false;
-homelab.services.soularr.enable = false;
+homelab.services.cratedigger.enable = false;
 homelab.services.inotify-receiver.enable = false;
 homelab.mounts.bindfsMusic.enable = false;
 ```
@@ -490,14 +490,14 @@ To move back to doc2:
 
 1. Stop services on downloader:
 ```bash
-ssh downloader "sudo systemctl stop soularr.timer slskd lidarr"
+ssh downloader "sudo systemctl stop cratedigger.timer slskd lidarr"
 ```
 
 2. Re-enable in `hosts/doc2/configuration.nix`:
 ```nix
 homelab.services.lidarr.enable = true;
 homelab.services.slskd.enable = true;
-homelab.services.soularr.enable = true;
+homelab.services.cratedigger.enable = true;
 homelab.services.inotify-receiver.enable = true;
 homelab.mounts.bindfsMusic.enable = true;
 ```
@@ -518,14 +518,14 @@ ssh doc2 "sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --ref
 1. **VPN for slskd**: Downloader is routed through VPN at router level (pfSense). No per-service VPN config needed.
 2. **Reverse proxy**: Use Caddy on cad (192.168.1.6) — wildcard DNS `*.ablz.au` already points there. Add `lidarr.ablz.au` and `slskd.ablz.au` entries.
 3. **Inotify receiver on doc2**: Disable via NixOS config (`enable = false`), leave all code in the repo for rollback.
-4. **Soularr fork**: Clone `github:abl030/soularr` on downloader. Verify monitored-release patch works with pip-installed deps.
+4. **Cratedigger fork**: Clone `github:abl030/cratedigger` on downloader. Verify monitored-release patch works with pip-installed deps.
 5. **Lidarr download clients**: Deluge on downloader uses categories for Sonarr/Radarr. Add a `lidarr` category.
 
 ## Files Changed
 
 | File | Change |
 |------|--------|
-| `hosts/doc2/configuration.nix` | Disable lidarr, slskd, soularr, inotify-receiver, bindfsMusic (set `enable = false`) |
+| `hosts/doc2/configuration.nix` | Disable lidarr, slskd, cratedigger, inotify-receiver, bindfsMusic (set `enable = false`) |
 | `hosts/doc2/configuration.nix` | Remove lidarr.ablz.au and slskd.ablz.au from localProxy.hosts |
 | `/etc/caddy/Caddyfile` on cad | Add lidarr.ablz.au and slskd.ablz.au reverse proxy entries |
 

--- a/docs/music-pipeline-postmortem.md
+++ b/docs/music-pipeline-postmortem.md
@@ -2,7 +2,7 @@
 
 ## What We Built
 
-Automated music acquisition pipeline: **Lidarr** (want list) -> **Soularr** (bridge) -> **slskd** (Soulseek downloads), with NZBGet as a secondary download source via Usenet/Newznab indexers. All running as podman containers on doc1 (proxmox-vm).
+Automated music acquisition pipeline: **Lidarr** (want list) -> **Cratedigger** (bridge) -> **slskd** (Soulseek downloads), with NZBGet as a secondary download source via Usenet/Newznab indexers. All running as podman containers on doc1 (proxmox-vm).
 
 ## What Went Wrong (and token cost)
 
@@ -50,7 +50,7 @@ This also caused directory name mismatches — we created a directory with an AS
 - Add a remote path mapping: `/downloads/completed` -> correct container path
 - Or route ALL downloads through a common path
 
-### 5. Soularr quality settings iteration (LOW token cost)
+### 5. Cratedigger quality settings iteration (LOW token cost)
 
 **Problem:** Had to iterate through quality settings:
 1. Started with FLAC-first (default) -> downloaded FLAC that would be rejected by 320 profile
@@ -161,7 +161,7 @@ NZBGet reports paths as `/downloads/completed/Music/...` but Lidarr has no mappi
 - Cutoff: High Quality Lossy (contains MP3-320)
 - Behavior: grabs anything available, keeps upgrading until MP3-320
 
-**Soularr `allowed_filetypes` order:**
+**Cratedigger `allowed_filetypes` order:**
 ```ini
 allowed_filetypes = mp3 320,flac 24/192,flac 16/44.1,flac,mp3
 ```

--- a/docs/wiki/infrastructure/media-filesystem.md
+++ b/docs/wiki/infrastructure/media-filesystem.md
@@ -23,7 +23,7 @@ The current split:
 | TV Shows | `/mnt/data/Media/TV Shows` (tower NFS) | `/mnt/virtio/media_metadata/TV Shows` (prom virtiofs) |
 | Music    | `/mnt/virtio/Music` (prom virtiofs) | `/mnt/virtio/media_metadata/Music` (prom virtiofs) |
 
-Music is the odd one — both branches are on prom virtiofs because the canonical music tree itself moved to prom (it's the 668GB `nvmeprom/containers/Music` ZFS child dataset, served to soularr/lidarr/beets on doc2 via the same virtiofs). Movies and TV's media still lives on tower's spinning disks; only their metadata moved.
+Music is the odd one — both branches are on prom virtiofs because the canonical music tree itself moved to prom (it's the 668GB `nvmeprom/containers/Music` ZFS child dataset, served to cratedigger/lidarr/beets on doc2 via the same virtiofs). Movies and TV's media still lives on tower's spinning disks; only their metadata moved.
 
 ## Storage topology
 
@@ -45,7 +45,7 @@ Music is the odd one — both branches are on prom virtiofs because the canonica
                     │                          (Phase 3 of #208; owned root:root 0755 so
                     │                          jellyfin-owned and root-owned children coexist.)
                     │
-                    ├── <all other service state>   atuin, immich, paperless, mealie, soularr, ...
+                    ├── <all other service state>   atuin, immich, paperless, mealie, cratedigger, ...
                     ▼
    ┌────────────────────────┬─────────────────────────┐
    │                        │                         │
@@ -72,7 +72,7 @@ Music is the odd one — both branches are on prom virtiofs because the canonica
 
 ## Why one broad `containers` mapping on every host
 
-doc1 and doc2 always had the full `containers` mapping because they're the service hosts — they need to see every service's state dir (immich, paperless, mealie, soularr, …). As of Phase 3 of #208, igpu follows the same pattern: jellyfin runs native (`dataRoot = /mnt/virtio/jellyfin`) alongside tdarr-node, so it needs the same broad view.
+doc1 and doc2 always had the full `containers` mapping because they're the service hosts — they need to see every service's state dir (immich, paperless, mealie, cratedigger, …). As of Phase 3 of #208, igpu follows the same pattern: jellyfin runs native (`dataRoot = /mnt/virtio/jellyfin`) alongside tdarr-node, so it needs the same broad view.
 
 Phase 1 originally tried a narrow approach for igpu — separate `music` + `media_metadata` directory mappings — to minimise blast radius. That worked for the Phase 1 scope (virtiofs music only) but fell apart in Phase 3 when we added jellyfin state, which would have required yet another narrow mapping. A single broad mapping is the cleaner pattern and matches the rest of the fleet. See the [decision history](#decision-history) below.
 

--- a/docs/wiki/services/retired-container-stacks.md
+++ b/docs/wiki/services/retired-container-stacks.md
@@ -64,7 +64,7 @@ in the former GitHub issue #208)
 - `jdownloader2/` → OCI container via `services/jdownloader2.nix`
 - `kopia/` → `services/kopia.nix`
 - `mealie/` → `services/mealie.nix`
-- `music/` → `services/{lidarr,slskd,soularr,discogs}.nix` (the stack split into
+- `music/` → `services/{lidarr,slskd,cratedigger,discogs}.nix` (the stack split into
   per-app modules)
 - `musicbrainz/` → `services/musicbrainz.nix` (NixOS-native mirror, replaced
   the compose-based mb-docker mirror — see `docs/wiki/services/` for the

--- a/flake.lock
+++ b/flake.lock
@@ -58,6 +58,24 @@
         "type": "github"
       }
     },
+    "cratedigger-src": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1776658583,
+        "narHash": "sha256-PMtlKRWdOy5g475cBcmdalxn/uK8RNc0B9rK9SgGR0I=",
+        "owner": "abl030",
+        "repo": "cratedigger",
+        "rev": "db8000567e164bfec1bb0c3b30f7a925144ca2da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "abl030",
+        "repo": "cratedigger",
+        "type": "github"
+      }
+    },
     "discogs-src": {
       "flake": false,
       "locked": {
@@ -469,16 +487,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -500,16 +518,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -612,6 +630,7 @@
         "claude-code-nix": "claude-code-nix",
         "claude-plugin-ha-skills": "claude-plugin-ha-skills",
         "codex-cli-nix": "codex-cli-nix",
+        "cratedigger-src": "cratedigger-src",
         "discogs-src": "discogs-src",
         "disko": "disko",
         "episodic-memory": "episodic-memory",
@@ -628,7 +647,7 @@
         "netwatch": "netwatch",
         "nixos-hardware": "nixos-hardware",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "ntopng-exporter-src": "ntopng-exporter-src",
         "nvchad4nix": "nvchad4nix",
         "pfsense-exporter-src": "pfsense-exporter-src",
@@ -636,7 +655,6 @@
         "sheets": "sheets",
         "slskd-mcp": "slskd-mcp",
         "sops-nix": "sops-nix",
-        "soularr-src": "soularr-src",
         "spicetify-nix": "spicetify-nix",
         "systems": "systems_7",
         "terranix": "terranix",
@@ -705,24 +723,6 @@
       "original": {
         "owner": "mic92",
         "repo": "sops-nix",
-        "type": "github"
-      }
-    },
-    "soularr-src": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1776656118,
-        "narHash": "sha256-GZcnpN3P3u+ErUuTLyJWK/HZFkmvornMEuBdltc/qIo=",
-        "owner": "abl030",
-        "repo": "soularr",
-        "rev": "ac4f0daa80c3fb5509d34f4bee1bab9a5795a73b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "abl030",
-        "repo": "soularr",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -101,8 +101,8 @@
       flake = false;
     };
 
-    soularr-src = {
-      url = "github:abl030/soularr";
+    cratedigger-src = {
+      url = "github:abl030/cratedigger";
     };
 
     discogs-src = {

--- a/hosts/doc2/configuration.nix
+++ b/hosts/doc2/configuration.nix
@@ -123,7 +123,7 @@
         downloadDir = "/mnt/virtio/music/slskd";
         musicDir = "/mnt/virtio/music/lidarr";
       };
-      soularr = {
+      cratedigger = {
         enable = true;
         downloadDir = "/mnt/virtio/music/slskd";
       };
@@ -221,10 +221,10 @@
     };
   };
 
-  # Soularr — host-specific app tuning. Everything else lives in the
-  # homelab wrapper at modules/nixos/services/soularr.nix, which configures
-  # the upstream module from the soularr flake (inputs.soularr-src).
-  services.soularr.beetsValidation.verifiedLosslessTarget = "opus 128";
+  # Cratedigger — host-specific app tuning. Everything else lives in the
+  # homelab wrapper at modules/nixos/services/cratedigger.nix, which configures
+  # the upstream module from the cratedigger flake (inputs.cratedigger-src).
+  services.cratedigger.beetsValidation.verifiedLosslessTarget = "opus 128";
 
   # Virtiofs mount — ALL service state lives here
   # This is the whole point: storage decoupled from compute.

--- a/modules/nixos/services/cratedigger.nix
+++ b/modules/nixos/services/cratedigger.nix
@@ -1,8 +1,8 @@
-# Soularr — homelab wrapper around the upstream module.
+# Cratedigger — homelab wrapper around the upstream module.
 # =====================================================
 #
-# The actual NixOS module lives in the soularr repo at nix/module.nix and is
-# consumed via inputs.soularr-src.nixosModules.default. This wrapper supplies
+# The actual NixOS module lives in the cratedigger repo at nix/module.nix and is
+# consumed via inputs.cratedigger-src.nixosModules.default. This wrapper supplies
 # the homelab-specific bits the upstream module deliberately doesn't know
 # about:
 #
@@ -10,22 +10,22 @@
 #   - the nspawn PostgreSQL container backing the pipeline DB
 #   - the redis instance that the web UI's cache uses
 #   - the localProxy entry that puts the web UI behind music.ablz.au
-#   - systemd ordering against container@soularr-db.service
+#   - systemd ordering against container@cratedigger-db.service
 #
 # Tuning notes that used to live in the giant downstream module now live in
-# the upstream module's option docs (or in the soularr README for quality
+# the upstream module's option docs (or in the cratedigger README for quality
 # rank tuning). Anything past the option-set below is purely homelab plumbing.
 #
 # Network topology (unchanged from the legacy module):
 #   doc2 has two NICs on 192.168.1.0/24:
-#     ens18 = 192.168.1.35 (main, DHCP) — Lidarr, soularr, NFS, everything else
+#     ens18 = 192.168.1.35 (main, DHCP) — Lidarr, cratedigger, NFS, everything else
 #     ens19 = 192.168.1.36 (VPN, static) — slskd Soulseek traffic only
 #   See slskd.nix for the policy routing.
 #
 # Debugging:
-#   journalctl -u soularr -f              — watch a run in real time
-#   sudo systemctl start soularr          — trigger a run now
-#   sudo cat /var/lib/soularr/config.ini  — verify rendered config
+#   journalctl -u cratedigger -f              — watch a run in real time
+#   sudo systemctl start cratedigger          — trigger a run now
+#   sudo cat /var/lib/cratedigger/config.ini  — verify rendered config
 #   curl -s localhost:5030/api/v0/searches -H 'X-API-Key: <key>' | jq
 #                                         — check slskd search queue
 {
@@ -35,27 +35,27 @@
   inputs,
   ...
 }: let
-  cfg = config.homelab.services.soularr;
+  cfg = config.homelab.services.cratedigger;
 
   # PostgreSQL in an nspawn container — data lives at cfg.dataDir/postgres
   pgc = import ../lib/mk-pg-container.nix {
     inherit pkgs;
-    name = "soularr";
+    name = "cratedigger";
     hostNum = 5;
     dataDir = cfg.dataDir;
   };
 
   sopsFile = config.homelab.secrets.sopsFile "soularr.env";
 in {
-  imports = [inputs.soularr-src.nixosModules.default];
+  imports = [inputs.cratedigger-src.nixosModules.default];
 
-  options.homelab.services.soularr = {
-    enable = lib.mkEnableOption "Soularr — Soulseek download pipeline (homelab wrapper)";
+  options.homelab.services.cratedigger = {
+    enable = lib.mkEnableOption "Cratedigger — Soulseek download pipeline (homelab wrapper)";
 
     dataDir = lib.mkOption {
       type = lib.types.str;
-      default = "/mnt/virtio/soularr";
-      description = "Directory for all Soularr state (contains postgres subdirectory).";
+      default = "/mnt/virtio/cratedigger";
+      description = "Directory for all Cratedigger state (contains postgres subdirectory).";
     };
 
     downloadDir = lib.mkOption {
@@ -83,19 +83,19 @@ in {
       mode = "0400";
     };
 
-    systemd.services.soularr-secrets-split = {
+    systemd.services.cratedigger-secrets-split = {
       description = "Split soularr.env into per-key secret files for the upstream module";
       wantedBy = ["multi-user.target"];
-      before = ["soularr.service" "soularr-web.service" "soularr-db-migrate.service"];
+      before = ["cratedigger.service" "cratedigger-web.service" "cratedigger-db-migrate.service"];
       after = ["sysinit-reactivation.target"];
       restartTriggers = [config.sops.secrets."soularr/env".path];
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
-        ExecStart = pkgs.writeShellScript "soularr-secrets-split" ''
+        ExecStart = pkgs.writeShellScript "cratedigger-secrets-split" ''
           set -euo pipefail
           env_file="${config.sops.secrets."soularr/env".path}"
-          out_dir="/run/soularr-secrets"
+          out_dir="/run/cratedigger-secrets"
           # Dir is 0750 root:users + files are 0440 root:users so operators
           # in the `users` group (notably abl030) can read the raw secrets
           # when running `pipeline-cli force-import` from a non-root shell.
@@ -119,7 +119,7 @@ in {
     # ---------------------------------------------------------------------
     # PostgreSQL container — pipeline DB.
     # ---------------------------------------------------------------------
-    containers.soularr-db = pgc.containerConfig;
+    containers.cratedigger-db = pgc.containerConfig;
 
     systemd.tmpfiles.rules = [
       "d ${cfg.dataDir} 0755 root root -"
@@ -129,7 +129,7 @@ in {
     # ---------------------------------------------------------------------
     # Redis cache for the web UI (in-memory only, no persistence).
     # ---------------------------------------------------------------------
-    services.redis.servers.soularr = {
+    services.redis.servers.cratedigger = {
       enable = true;
       port = 6379;
       save = []; # no persistence — pure cache
@@ -141,24 +141,24 @@ in {
     homelab.localProxy.hosts = [
       {
         host = "music.ablz.au";
-        port = config.services.soularr.web.port;
+        port = config.services.cratedigger.web.port;
       }
     ];
 
     # ---------------------------------------------------------------------
     # Wire up the upstream module.
     # ---------------------------------------------------------------------
-    services.soularr = {
+    services.cratedigger = {
       enable = true;
 
       # config.ini is world-readable (0644) since issue #117 — it contains
       # only *_file paths, no secrets. The raw secrets live under
-      # /run/soularr-secrets (group-readable by `users`, see the splitter
+      # /run/cratedigger-secrets (group-readable by `users`, see the splitter
       # above) and the Python pipeline reads them on demand via
-      # SoularrConfig.resolved_*() accessors.
+      # CratediggerConfig.resolved_*() accessors.
 
       slskd = {
-        apiKeyFile = "/run/soularr-secrets/SOULARR_SLSKD_API_KEY";
+        apiKeyFile = "/run/cratedigger-secrets/SOULARR_SLSKD_API_KEY";
         downloadDir = cfg.downloadDir;
       };
 
@@ -180,20 +180,20 @@ in {
         meelo = {
           enable = true;
           url = "https://meelo.ablz.au";
-          usernameFile = "/run/soularr-secrets/MEELO_USERNAME";
-          passwordFile = "/run/soularr-secrets/MEELO_PASSWORD";
+          usernameFile = "/run/cratedigger-secrets/MEELO_USERNAME";
+          passwordFile = "/run/cratedigger-secrets/MEELO_PASSWORD";
         };
         plex = {
           enable = true;
           url = "https://plex.ablz.au";
-          tokenFile = "/run/soularr-secrets/PLEX_TOKEN";
+          tokenFile = "/run/cratedigger-secrets/PLEX_TOKEN";
           librarySectionId = 3;
           pathMap = "/mnt/virtio/Music/Beets:/prom_music";
         };
         jellyfin = {
           enable = true;
           url = "https://jelly.ablz.au";
-          tokenFile = "/run/soularr-secrets/JELLYFIN_TOKEN";
+          tokenFile = "/run/cratedigger-secrets/JELLYFIN_TOKEN";
         };
       };
 
@@ -205,26 +205,26 @@ in {
 
     # ---------------------------------------------------------------------
     # Homelab-specific systemd ordering against the nspawn DB container.
-    # The upstream module already sets the cross-unit deps among the soularr
-    # services themselves; we just splice in container@soularr-db.service.
+    # The upstream module already sets the cross-unit deps among the cratedigger
+    # services themselves; we just splice in container@cratedigger-db.service.
     # restartTriggers ensure switch-to-configuration re-runs the migrate
     # oneshot whenever the container derivation changes.
     # ---------------------------------------------------------------------
-    systemd.services.soularr-db-migrate = {
-      after = ["container@soularr-db.service"];
-      requires = ["container@soularr-db.service"];
-      restartTriggers = [config.systemd.units."container@soularr-db.service".unit];
+    systemd.services.cratedigger-db-migrate = {
+      after = ["container@cratedigger-db.service"];
+      requires = ["container@cratedigger-db.service"];
+      restartTriggers = [config.systemd.units."container@cratedigger-db.service".unit];
     };
 
-    systemd.services.soularr = {
-      after = ["slskd.service" "container@soularr-db.service"];
-      wants = ["slskd.service" "container@soularr-db.service"];
+    systemd.services.cratedigger = {
+      after = ["slskd.service" "container@cratedigger-db.service"];
+      wants = ["slskd.service" "container@cratedigger-db.service"];
     };
 
-    systemd.services.soularr-web = {
-      after = ["container@soularr-db.service" "redis-soularr.service"];
-      wants = ["container@soularr-db.service" "redis-soularr.service"];
-      restartTriggers = [config.systemd.units."container@soularr-db.service".unit];
+    systemd.services.cratedigger-web = {
+      after = ["container@cratedigger-db.service" "redis-cratedigger.service"];
+      wants = ["container@cratedigger-db.service" "redis-cratedigger.service"];
+      restartTriggers = [config.systemd.units."container@cratedigger-db.service".unit];
     };
   };
 }

--- a/modules/nixos/services/default.nix
+++ b/modules/nixos/services/default.nix
@@ -29,7 +29,7 @@
     ./atuin.nix
     ./lidarr.nix
     ./slskd.nix
-    ./soularr.nix
+    ./cratedigger.nix
     ./discogs.nix
     ./paperless.nix
     ./mealie.nix

--- a/modules/nixos/services/jellyfin.nix
+++ b/modules/nixos/services/jellyfin.nix
@@ -361,7 +361,7 @@ in {
         "d ${cfg.jellystat.dataDir} 0755 ${hostConfig.user} users -"
         "d ${cfg.jellystat.dataDir}/backup-data 0755 ${hostConfig.user} users -"
         # mk-pg-container bindmounts ${dataDir}/postgres into the nspawn.
-        # 0700 root:root matches the pattern used by soularr/immich/etc.
+        # 0700 root:root matches the pattern used by cratedigger/immich/etc.
         "d ${cfg.jellystat.dataDir}/postgres 0700 root root -"
       ];
 

--- a/modules/nixos/services/slskd.nix
+++ b/modules/nixos/services/slskd.nix
@@ -112,7 +112,7 @@ in {
       };
     };
 
-    # World-writable — soularr + lidarr both need full access to downloads
+    # World-writable — cratedigger + lidarr both need full access to downloads
     systemd.services.slskd.serviceConfig.UMask = "0000";
 
     # slskd user needs media access


### PR DESCRIPTION
Companion to https://github.com/abl030/cratedigger/pull/135.

See commit message + cratedigger#134 for full detail. Deployed live on doc2 (DB renamed, state dirs mv'd, nspawn container rebuilt, 1610 album_requests preserved).

Merging this makes master match what's actually running.