### PR TITLE
ssh phase 1: structured authorized_keys + drop global agent forwarding

### DIFF
--- a/hosts.nix
+++ b/hosts.nix
@@ -21,13 +21,34 @@
 #    Set 'readonly = true' for VMs that should not be managed by automation.
 #
 let
+  # Role-based authorized-keys inventory (Phase 1 of #241).
+  #
+  # Plain strings are still accepted (legacy compat); attrsets get rendered
+  # to authorized_keys lines with from=/expiry-time/restrict/command prefixes
+  # by `nix/render-authorized-keys.nix`, called from base.nix and homelab.ssh.
+  #
+  # Restrictions are conservative for Phase 1 — phone is locked to the tailnet
+  # with a quarterly expiry; master and pihole keys remain unrestricted because
+  # doc1's rolling-flake-update and various ops scripts still need broad
+  # access. Phase 3 (#241) tightens these once the CA is in place.
   masterKeys = [
-    # Master Fleet Identity
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDGR7mbMKs8alVN4K1ynvqT5K3KcXdeqlV77QQS0K1qy master-fleet-identity"
-    # Manual Keys
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJnFw/zW4X+1pV2yWXQwaFtZ23K5qquglAEmbbqvLe5g root@pihole"
-    # Termux on Galaxy A55 — separate identity, revocable if phone is lost
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHmUU7BKMmjF53n0uCOg1w6uRe1erG13nembAiIE8ybN phone-fleet@s-a55"
+    # Master fleet identity. Currently unrestricted; Phase 3 moves this onto
+    # a cold YubiKey and adds `from="100.64.0.0/10"` + `expiry-time`.
+    {
+      key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDGR7mbMKs8alVN4K1ynvqT5K3KcXdeqlV77QQS0K1qy master-fleet-identity";
+    }
+    # Legacy root@pihole — kept for now, audit if still needed.
+    {
+      key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJnFw/zW4X+1pV2yWXQwaFtZ23K5qquglAEmbbqvLe5g root@pihole";
+    }
+    # Termux on Galaxy A55. Tailnet-only (CGNAT 100.64.0.0/10) — phone is
+    # never on the LAN with this key. Quarterly expiry forces a rotation
+    # ritual; bump `expiryTime` when refreshing the key.
+    {
+      key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHmUU7BKMmjF53n0uCOg1w6uRe1erG13nembAiIE8ybN phone-fleet@s-a55";
+      from = ["100.64.0.0/10"];
+      expiryTime = "20260901";
+    }
   ];
 in {
   # Proxmox Infrastructure Configuration

--- a/modules/home-manager/services/ssh.nix
+++ b/modules/home-manager/services/ssh.nix
@@ -64,7 +64,12 @@ in {
 
           # Global Defaults (merged at the end)
           "*" = {
-            forwardAgent = true; # Useful for git
+            # ForwardAgent is OFF by default (Phase 1 of #241). The previous
+            # `forwardAgent = true` on `*` exposed the local key surface to
+            # every host we SSH into — a compromised remote could use the
+            # forwarded agent to hop further. Re-enable per host only where
+            # genuinely needed (git operations against Forgejo, etc.).
+            forwardAgent = false;
             setEnv = {TERM = "xterm-256color";};
 
             # Explicitly disable X11

--- a/modules/nixos/profiles/base.nix
+++ b/modules/nixos/profiles/base.nix
@@ -286,8 +286,12 @@
       # Core groups. Hosts can add more (e.g. docker) via extraGroups in their own config
       extraGroups = ["wheel" "networkmanager"];
 
-      # Automatically pull authorized keys from hosts.nix
-      openssh.authorizedKeys.keys = hostConfig.authorizedKeys or [];
+      # Automatically pull authorized keys from hosts.nix. Entries can be
+      # plain strings (legacy) or structured attrsets (Phase 1 of #241);
+      # the renderer handles both.
+      openssh.authorizedKeys.keys =
+        (import ../../../nix/render-authorized-keys.nix {inherit lib;}).renderList
+        (hostConfig.authorizedKeys or []);
     }
     // lib.optionalAttrs (hostConfig ? initialHashedPassword) {
       # Optional per-host initial password hash (set in hosts.nix).

--- a/modules/nixos/services/ssh/default.nix
+++ b/modules/nixos/services/ssh/default.nix
@@ -63,7 +63,11 @@ in {
     };
 
     # 2. Authorized Keys (Sourced from hosts.nix)
-    users.users.${user}.openssh.authorizedKeys.keys = authorizedKeys;
+    # Entries can be plain strings (legacy) or structured attrsets with
+    # from=/expiry-time/restrict/command (Phase 1 of #241).
+    users.users.${user}.openssh.authorizedKeys.keys =
+      (import ../../../../nix/render-authorized-keys.nix {inherit lib;}).renderList
+      authorizedKeys;
 
     # 3. Decrypt the Master Identity (System Level)
     # We do this here because only root can read the Host Key needed to decrypt it

--- a/nix/render-authorized-keys.nix
+++ b/nix/render-authorized-keys.nix
@@ -1,0 +1,40 @@
+# Render an authorized_keys list that mixes plain strings (legacy) and
+# structured entries (Phase 1 of #241).
+#
+# A structured entry is an attrset:
+#   {
+#     key         = "ssh-ed25519 AAAA... comment";  # required
+#     from        = [ "100.64.0.0/10" "..." ];      # optional, becomes from="..."
+#     expiryTime  = "20260901";                     # optional, OpenSSH 9.4+ expiry-time="..."
+#     restrict    = false;                          # optional, adds the `restrict` keyword
+#     command     = null;                           # optional, force-command="..."
+#     extraOptions = [ ];                           # optional, raw extra option strings
+#   }
+#
+# Plain strings are passed through unchanged so existing entries don't have
+# to be migrated at once.
+#
+# Output: list of strings ready for users.users.<u>.openssh.authorizedKeys.keys.
+{lib}: let
+  renderEntry = entry:
+    if builtins.isString entry
+    then entry
+    else let
+      opts =
+        lib.optional (entry.from or null != null)
+        ''from="${lib.concatStringsSep "," entry.from}"''
+        ++ lib.optional (entry.expiryTime or null != null)
+        ''expiry-time="${entry.expiryTime}"''
+        ++ lib.optional (entry.restrict or false) "restrict"
+        ++ lib.optional (entry.command or null != null)
+        ''command="${entry.command or ""}"''
+        ++ (entry.extraOptions or []);
+      prefix =
+        if opts == []
+        then ""
+        else "${lib.concatStringsSep "," opts} ";
+    in "${prefix}${entry.key}";
+in {
+  inherit renderEntry;
+  renderList = lib.map renderEntry;
+}


### PR DESCRIPTION
Phase 1 of the SSH re-architecture in #241 — no infra changes, just hardening the existing key surface.

## What

1. **`hosts.nix` `masterKeys`** moves from flat strings to structured attrsets:

   ```nix
   masterKeys = [
     { key = "ssh-ed25519 AAAA... master-fleet-identity"; }
     { key = "ssh-ed25519 AAAA... root@pihole"; }
     {
       key = "ssh-ed25519 AAAA... phone-fleet@s-a55";
       from = ["100.64.0.0/10"];     # tailnet CGNAT only
       expiryTime = "20260901";       # quarterly rotation
     }
   ];
   ```

2. **`nix/render-authorized-keys.nix`** is a new renderer that turns each entry (plain string or structured attrset) into an `authorized_keys` line with options prefix. Both `base.nix:290` and `homelab.ssh:66` call it, so flat strings keep working unchanged for any host that doesn't migrate.

3. **`modules/home-manager/services/ssh.nix`** flips global `forwardAgent` from `true` to `false`. Previously every `ssh <host>` exposed the local agent to the remote — compromised remote could hop further. Per-host opt-in only.

## Concrete result

Rendered phone key for doc2:
```
from="100.64.0.0/10",expiry-time="20260901" ssh-ed25519 AAAA... phone-fleet@s-a55
```

Rendered HM ssh config:
```
Host *
  ForwardAgent no
  SetEnv TERM="xterm-256color"
```

Master and pihole keys remain unrestricted on this PR because doc1's rolling-flake-update and the various ops scripts still use the master key broadly. Phase 3 of #241 will move the master onto a cold YubiKey with `from=` + `expiry-time` once the CA is in place.

## Verified

- `nix build .#nixosConfigurations.doc2.config.system.build.toplevel` ✅
- `nix build .#nixosConfigurations.proxmox-vm.config.system.build.toplevel` ✅
- `nix build .#nixosConfigurations.framework.config.system.build.toplevel` ✅
- Rendered authorized_keys list inspected via `nix eval --json …`
- Rendered HM ssh config inspected via the activation package's `.ssh/config` symlink

## Out of scope

- Tailscale SSH (`services.tailscale.ssh = true` + ACL hujson) — Phase 2 of #241.
- step-ca on doc2 — Phase 2 of #241.
- YubiKey-PIV root CA on prom — Phase 3 of #241.
- prom (bare-metal Proxmox, not in this nix repo) needs a manual `authorized_keys` update mirroring this change.

## Notes

- Both `base.nix` and `homelab.ssh` set `users.users.<u>.openssh.authorizedKeys.keys`. NixOS module merging concatenates → entries appear duplicated in the rendered list. This is pre-existing behaviour, not introduced by this PR. Worth a follow-up to consolidate to one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)