### PR TITLE
feat(mailarchive): NixOS module to retire Win10 MailStore VM

### DIFF
--- a/docs/brainstorms/2026-05-04-mailstore-vm-probe-result.md
+++ b/docs/brainstorms/2026-05-04-mailstore-vm-probe-result.md
@@ -1,0 +1,110 @@
+# Mailstore VM Replacement — DavMail/OAuth Probe Result
+
+**Date:** 2026-05-04
+**Status:** Probe complete and end-to-end verified. **Architecture 1 (mbsync direct + Thunderbird client_id) is locked in** — confirmed working with a live IMAP fetch.
+**Companion to:** `2026-05-04-mailstore-vm-replacement-research.md`
+
+## What we tested
+
+Section 5 of the research doc proposed a 30-minute pre-implementation probe to detect whether the work O365 tenant (cullenwines.com.au) imposes Conditional Access policies that would kill the project. We ran a variant on epimetheus, using DavMail 6.6.0 from nixpkgs as the OAuth driver.
+
+## Outcomes observed
+
+**1. DavMail's client_id is blocked at the consent layer.**
+
+When the IMAP login was attempted via DavMail (which uses the published app id `facd6cff-a294-4415-b59f-c5b01937d7bd`), Microsoft's sign-in completed normally (credentials accepted, MFA passed, no Conditional Access block) — but the consent screen showed:
+
+> DavMail needs permission to access resources in your organization that only an admin can grant. Please ask an admin to grant permission to this app before you can use it.
+
+The "Have an admin account?" link was offered. The user (limited Entra admin role) does not have permissions to grant tenant-wide consent.
+
+**2. Thunderbird's app id is already consented tenant-wide.**
+
+In the cullenwines.com.au Entra Admin Center → Enterprise Applications, Thunderbird is listed as "Activated" with its app id visible. That means a previous tenant admin (or an earlier policy regime) granted consent to Thunderbird, and any OAuth flow using Thunderbird's client_id is accepted on this tenant without further consent prompts.
+
+## What the probe rules out and rules in
+
+**Rules out:**
+- **Conditional Access blocking the headless OAuth flow.** CA didn't fire on either DavMail's or Thunderbird's auth attempts — sign-in itself succeeded both times. The project is *viable* (the section-5 worst case did not materialize).
+- **Architecture 2 (DavMail) on this tenant without IT involvement.** DavMail's client_id requires admin consent we can't grant ourselves. Architecture 2 would require an IT ticket, which the user explicitly preferred to avoid.
+- **Architecture 3 (Thunderbird-in-a-container) as a workaround.** Containers don't bypass tenant OAuth policy — the policy is keyed off the client_id, not the network origin. Architecture 3 hits the *same* consent layer Architecture 1 does, with strictly more moving parts.
+
+**Rules in:**
+- **Architecture 1 (mbsync + cyrus-sasl-xoauth2 + Thunderbird client_id direct to O365).** This is now the recommended path. Microsoft will accept the OAuth flow because Thunderbird is pre-consented; refresh tokens last as long as Microsoft's standard `offline_access` lifetime (90 days inactive / unlimited if used).
+
+## Revised architecture recommendation
+
+**Architecture 1.** The original research doc preferred Architecture 2 because it shifts the maintenance burden of tracking Microsoft's auth changes onto DavMail's maintainer. That logic is still sound in the abstract, but on *this specific tenant* the consent gate flips the calculus: DavMail can't run here without IT intervention, and the user has explicitly opted not to involve IT.
+
+**Trade-offs we accept by going Arch 1:**
+
+- **Microsoft client_id rotation risk.** Microsoft retired the older Thunderbird client_id `08162f7c-0fd2-4200-a84a-f25a4db0b584` on 2024-08-01. They could do it again to `9e5f94bc-…`. Recovery: discover the new id from Mozilla's published Thunderbird sources, update our helper script's config, re-bootstrap the refresh token. ~1 hour of work, zero data loss.
+- **No abstraction over Microsoft auth changes.** When MS adjusts redirect-URI rules or scope behavior (as they did in March-April 2026), we patch our helper instead of pulling a DavMail release. Manageable if we keep the helper short and idiomatic.
+- **Self-managed token refresh.** mbsync's `PassCmd` invokes a helper every sync; the helper holds the refresh token (sops-encrypted) and exchanges it for a fresh access token. Standard pattern, well-trod by `mutt_oauth2.py` and `oauth2ms`.
+
+**Pre-condition to verify before building** (small but important):
+
+- Confirm the Thunderbird app id registered in cullenwines.com.au's Enterprise Apps is the *current* `9e5f94bc-e8a4-4e73-b8be-63364c29d753`, not the retired `08162f7c-…`. If it's the retired id, we're on a grandfathered token that won't survive re-auth — and we'd need a different fallback (likely: ask IT to add tenant-wide consent for the current Thunderbird id, which is a single-click admin action and doesn't require any new app registration).
+
+## What changes in the implementation plan
+
+- **Drop DavMail entirely.** No NixOS service, no Java daemon on doc2, no admin-consent dependency.
+- **Module reduces to: mbsync per account + a small token-refresh helper.** Both work and Gmail accounts use the same fetcher with different `PassCmd`s and different client_ids (Thunderbird's for work O365, the user's own GCP project for Gmail).
+- **Helper script:** ship as `pkgs.writeShellApplication` wrapping a Python one-liner that exchanges refresh-token → access-token. ~20 lines.
+- **Bootstrap procedure:** documented one-time step using a static localhost listener (not Microsoft's OOB redirect) to capture the initial refresh token, then sops-encrypt it. We'll write this as a runbook during `/ce-plan`.
+- **Sops layout:** per-account `OAUTH_CLIENT_ID`, `OAUTH_REFRESH_TOKEN`, plus a `OAUTH_TENANT` (= `common`) for O365 and `OAUTH_CLIENT_SECRET` for Gmail (Google requires it; Microsoft doesn't for public clients).
+
+## Gmail side: unchanged
+
+The probe did not touch the Gmail side. The plan there remains: register a personal-use OAuth client in the user's own Google Cloud project, use the standard installed-app flow with localhost redirect, store refresh token in sops. This is well-trodden ground and not affected by Microsoft policy.
+
+## End-to-end verification (Architecture 1)
+
+After the consent-layer probe identified Architecture 1 as the path, a second probe
+run a Python script (~120 lines) that exercises the full mbsync auth chain end-to-end:
+
+1. Microsoft device-code OAuth with Thunderbird's `client_id`
+2. Capture `refresh_token`; round-trip it through Microsoft's token endpoint
+3. Decode the issued access-token JWT and verify claims
+4. Connect TLS to `outlook.office365.com:993`
+5. Send `AUTHENTICATE XOAUTH2` with the access token
+6. Run `LIST "" "*"` to confirm full mailbox visibility
+
+**Results:**
+
+| Step | Result |
+| --- | --- |
+| Device-code → tokens | ✅ access_token + refresh_token issued |
+| Refresh-token round-trip | ✅ new access_token issued |
+| JWT `aud` claim | ✅ `https://outlook.office.com` |
+| JWT `appid` claim | ✅ `9e5f94bc-e8a4-4e73-b8be-63364c29d753` (Thunderbird) |
+| JWT `upn` / `unique_name` | ✅ `andy@cullenwines.com.au` |
+| JWT `scp` | ✅ `IMAP.AccessAsUser.All POP.AccessAsUser.All SMTP.Send` |
+| JWT `tid` | `32bffe65-3e64-414f-9d21-069572b800eb` (cullenwines.com.au) |
+| TLS IMAP connect | ✅ |
+| `AUTHENTICATE XOAUTH2` | ✅ `OK AUTHENTICATE completed.` |
+| `LIST "" "*"` | ✅ 332 folders returned |
+
+The first attempt at IMAP XOAUTH2 immediately after the initial consent failed with
+`AUTHENTICATE failed.` — this is Microsoft's known eventual-consistency between
+the auth issuer and Exchange Online's IMAP service on first-auth for an app
+identity. A retry ~5 minutes later succeeded; in production this won't matter
+because the bootstrap happens once per refresh-token rotation (90+ days),
+followed by uninterrupted refresh-only auths.
+
+**Confirmed implications for the implementation plan:**
+
+- Only one `client_id` to embed in the helper: `9e5f94bc-e8a4-4e73-b8be-63364c29d753`.
+- Tenant-routing endpoint is `/common/` (works because Thunderbird is consented
+  in the user's home tenant; Microsoft routes by `login_hint`).
+- Refresh-token lifetime tracks Microsoft default `offline_access` — 90 days
+  inactive, indefinite if used. Continuous mbsync polls easily exceed that.
+- Mailbox is large (332 folders, deep hierarchy) — migration plan must preserve
+  folder structure, which the EML+Maildir path already does.
+
+## Probe artifacts
+
+- `/tmp/davmail-probe/` and `/tmp/mailprobe/` — both removed (refresh-token file
+  was a real credential and was shred-deleted, not just `rm`).
+- DavMail tested at version `6.6.0` from nixpkgs unstable.
+- DavMail's app id (for reference if Architecture 2 ever becomes relevant again): `facd6cff-a294-4415-b59f-c5b01937d7bd`.

--- a/docs/brainstorms/2026-05-04-mailstore-vm-replacement-requirements.md
+++ b/docs/brainstorms/2026-05-04-mailstore-vm-replacement-requirements.md
@@ -1,0 +1,166 @@
+# Mailstore VM Replacement — Requirements
+
+**Date:** 2026-05-04
+**Status:** Requirements drafted; research and probe complete; ready for `/ce-plan`.
+**Owner:** abl030
+**Companion docs:**
+- `2026-05-04-mailstore-vm-replacement-research.md` — deep research output
+- `2026-05-04-mailstore-vm-probe-result.md` — pre-implementation OAuth probe; **revises the architecture choice from 2 to 1** because Thunderbird is already tenant-consented on cullenwines.com.au and DavMail is not.
+
+## Problem
+
+A Windows 10 VM (`prom`/VMID 102, ssh `root@192.168.1.12`) exists solely to run Thunderbird + MailStore Home for email archiving. Windows 10 is out of support; the VM is the last Windows host in the fleet. The setup persists because at the time it was built, OAuth/MFA against O365 and Gmail from Linux clients was painful enough that a "trusted" Windows MUA + a GUI archiver was the path of least resistance.
+
+The archive is the user's full personal+work email history (~11 GB), used as a deletion-resistant backup ("Google deletes my account tomorrow → I still have my life") more than as a search tool. Retrieval happens roughly 3x/year, when Gmail's own search fails or a work email was deleted prematurely.
+
+## Goal
+
+Replace the Windows VM with a Linux/NixOS-native solution that:
+- Continues to capture every personal Gmail and work O365 email (including attachments) with deletion-resistance
+- Stores them in an **open, non-proprietary format** so future search/UI tooling stays optional
+- Handles modern OAuth without registering an app in the work Entra tenant
+- Migrates the existing 11 GB MailStore archive into the new store, then retires MailStore entirely
+
+## Users and Use Cases
+
+Single user (abl030). Two use cases:
+
+1. **Backup-of-record** — passive accumulation; never touched.
+2. **Emergency retrieval** — ~3x/year, find a specific email/attachment that was deleted upstream or that Gmail's search can't surface.
+
+## Stated Requirements
+
+- **Sources:** personal Gmail + work O365 (outlook.com tenant). IMAP confirmed working on the work tenant today.
+- **OAuth:**
+  - Personal Gmail: user generates own GCP OAuth client — fine.
+  - Work O365: **must not require registering an app in the work Entra tenant.** User has limited admin access but prefers to avoid touching it.
+- **Storage:**
+  - Open format (Maildir is the obvious answer — one file per message, every client and indexer reads it).
+  - Located under `/mnt/data/Life/Andy/Email/` so existing Kopia backups (Wasabi + offsite) cover it without new infrastructure.
+- **Migration:** the 11 GB existing MailStore archive (`/mnt/data/Life/Andy/Email/Mailstore/`, MailStore Home `.dat`/`.rr` proprietary format) must be exported to Maildir and merged into the new store.
+- **Deletion-resistance:** the user deletes work emails after processing them. The archiver must capture mail before that deletion happens — i.e. either IMAP IDLE or polling fast enough that a same-day delete is still caught.
+- **Retire MailStore + the Windows VM** at end of project.
+
+## Inferred Decisions (confirmed)
+
+- Host the fetcher on **doc2** — matches the "stateful services live on doc2" fleet pattern.
+- Build as a NixOS module under `homelab.services.mailarchive` (name TBD), enabled in `hosts/doc2/configuration.nix`. Follow `.claude/rules/nixos-service-modules.md`.
+- Wire into `homelab.monitoring` so Uptime Kuma alerts when the fetcher stops pulling.
+- Secrets via `sops-nix` at `secrets/hosts/doc2/<service>.env` for OAuth tokens / refresh tokens / client_ids.
+- Output of this brainstorm = the deep research prompt below; user will run the research separately, then come back for ce-plan.
+
+## Out of Scope
+
+- Web-UI archive products (Mailpiler, Stalwart, Roundcube on top of local Dovecot, etc.) — overkill for 3x/year retrieval; the user explicitly does not want a "MailStore replacement" with its own UI baggage.
+- Replacing daily mail clients (work Outlook, Gmail web) — those stay as-is.
+- Adding search/indexing infrastructure (notmuch, mu, mairix) — Maildir leaves the door open; building it is a separate project.
+- Any work-tenant Entra app registration.
+- Keeping MailStore Home around as a "cold reader" for the legacy archive — explicit goal is full migration, no proprietary format hangover.
+
+## Success Criteria
+
+1. Windows VM 102 powered off and removed from the Proxmox inventory.
+2. Both Gmail and work O365 have a Maildir under `/mnt/data/Life/Andy/Email/` that is being updated continuously, verifiable by sending a test email to each and watching it land within minutes.
+3. The 11 GB MailStore archive is exported to Maildir and merged into the live archive (deduplicated against new fetches if there's overlap).
+4. Kopia snapshots include the new Maildir paths.
+5. An Uptime Kuma monitor is green and pages on persistent fetch failure.
+6. OAuth tokens refresh automatically — no manual re-auth required for at least 90 days of operation.
+
+## Risks and Open Questions
+
+- **Microsoft tightening borrowed client_ids.** The "Thunderbird OAuth client_id" trick that lets non-tenant-registered clients authenticate against arbitrary O365 tenants has been the historical workaround. Microsoft has been progressively tightening this and could revoke it at any time. Mitigation candidates: Davmail (which abstracts the auth dance and rotates as needed) or falling back to a Linux Thunderbird in a container.
+- **Tenant policies.** Work tenant might enable Conditional Access policies (device compliance, IP restrictions) that block headless OAuth flows even when the client_id is allowed. Needs verification.
+- **MailStore export fidelity.** MailStore Home does support EML/Maildir export, but folder structure, attachments, and metadata fidelity need verification before committing to migration.
+- **Future search/UI.** Deferred, but storage-format choice (Maildir) preserves the option.
+
+---
+
+## Deep Research Prompt
+
+> Use the following prompt for the deep-research pass. Goal is a recommendation with concrete trade-offs, not just a survey.
+
+```
+I need to replace a Windows 10 VM that exists solely to run Thunderbird + MailStore
+Home for email archiving. Replacement is a NixOS service on Linux running on a
+homelab VM (doc2, NixOS, x86_64). The new system must:
+
+  - Continuously archive (a) personal Gmail and (b) work Microsoft 365 / outlook.com
+    mail to Maildir on a local NFS-backed path, with deletion-resistance — the user
+    deletes work emails after processing, so the archiver must capture them first
+    (IMAP IDLE or fast polling).
+  - Authenticate via modern OAuth2.
+      * Personal Gmail: user has their own Google Cloud project and can register a
+        custom OAuth client — assume this path is open.
+      * Work O365: the user CANNOT register an app in the work Entra tenant. The
+        solution must use either (a) a borrowed/published client_id that O365
+        tolerates against arbitrary tenants (e.g. Thunderbird's), (b) a translation
+        bridge like Davmail that handles auth internally, or (c) some equivalent
+        approach. IMAP is confirmed enabled at the protocol level on the work tenant.
+  - Store one file per message in Maildir format under
+    /mnt/data/Life/Andy/Email/<account>/, so existing Kopia backups (to Wasabi and
+    an offsite home server) cover it without new infrastructure.
+  - Migrate ~11 GB of existing MailStore Home archive (proprietary .dat/.rr files)
+    into the new Maildir store as a one-time operation, then retire MailStore
+    entirely. No proprietary format hangover.
+  - Run as a NixOS module (the fleet uses sops-nix for secrets, systemd units,
+    Uptime Kuma for monitoring).
+
+Investigate and compare these candidate architectures, with a strong recommendation
+at the end:
+
+  1. Direct IMAP fetcher (mbsync/isync, getmail6, OfflineIMAP, or other) using a
+     borrowed OAuth client_id (typically Thunderbird's) for O365. Cover: which tool
+     has the cleanest XOAUTH2 story in 2026, IDLE support, NixOS packaging status,
+     refresh-token handling, and how vulnerable each is to Microsoft revoking
+     borrowed client_ids.
+
+  2. Davmail as a translation bridge: Davmail handles O365 auth internally and
+     exposes plain IMAP on localhost; any standard IMAP fetcher consumes it.
+     Evaluate Davmail's current health and maintenance velocity, resource cost,
+     NixOS packaging, failure modes, and whether its OAuth resilience justifies the
+     extra component.
+
+  3. Linux Thunderbird in a container, with a separate process exporting its local
+     store to Maildir. Closest to the current architecture. Evaluate practicality
+     of running TB headlessly, OAuth reliability, and whether this is just the Win
+     VM problem in a slightly nicer box.
+
+For each candidate, report:
+  - Whether it actually solves the no-tenant-app-registration constraint in 2026
+  - Operational fragility: what specifically breaks when Microsoft tightens auth,
+    and how fast recovery is
+  - NixOS / declarative-config friendliness
+  - 2026 health signal: recent commits, recent issues about O365 auth breaking,
+    community size
+
+Also research:
+  - Best path for one-time MailStore Home → Maildir migration. What does MailStore's
+    export actually preserve (folder structure, headers, attachments, dates)? Are
+    there third-party tools that read MailStore's .dat format directly?
+  - Whether Gmail's own client_id requirements have shifted (any need for OAuth app
+    verification, even for a personal-use app accessing only the user's own account?).
+  - Whether work O365 tenants commonly enforce Conditional Access policies that
+    would block a headless OAuth flow even when the client_id is accepted, and how
+    to detect this before committing to architecture 1 or 2.
+  - Deduplication strategy when merging the migrated MailStore archive against
+    newly-fetched live mail (e.g. messages that exist in both because the archive
+    is recent).
+
+Constraints:
+  - No work-tenant Entra app registration. Hard constraint.
+  - Output format must be Maildir or comparably open (one-file-per-message, plain
+    RFC822). No proprietary stores.
+  - Must run unattended for at least 90 days without manual re-auth.
+  - Should be expressible as a NixOS module that fits the project's existing service
+    pattern (modules/nixos/services/<name>.nix with options under
+    homelab.services.<name>, sops-nix secrets, Uptime Kuma monitor wiring).
+
+Deliver a ranked recommendation with the trade-offs that drove the ranking, plus a
+sketch of the NixOS module shape for the recommended option.
+```
+
+## Next Steps
+
+1. Run the deep research prompt above (any deep-research tool / agent).
+2. Review the recommendation; if a clear winner emerges, dispatch `/ce-plan` to design the NixOS module + migration runbook.
+3. Implement, deploy on doc2, run in parallel with the Win VM for ~2 weeks to verify deletion-resistance, then retire VM 102.

--- a/docs/brainstorms/2026-05-04-mailstore-vm-replacement-research.md
+++ b/docs/brainstorms/2026-05-04-mailstore-vm-replacement-research.md
@@ -1,0 +1,404 @@
+# Mailstore VM Replacement — Deep Research
+
+**Date:** 2026-05-04
+**Status:** Research complete; recommended path is DavMail + mbsync.
+**Owner:** abl030
+**Companion to:** `2026-05-04-mailstore-vm-replacement-requirements.md`
+
+---
+
+## 1. Executive Recommendation
+
+**Build Architecture 2: DavMail (as a NixOS service) + mbsync (isync) for Maildir landing + a separate mbsync configuration with the user's own GCP OAuth client for Gmail.** Both feed into `/mnt/data/Life/Andy/Email/<account>/` as Maildir.
+
+Three trade-offs drove the ranking:
+
+1. **DavMail decouples the Microsoft-auth problem from the fetcher.** Microsoft has tightened OAuth twice in 2026 alone (the redirect-URI flip in 6.6.0 / April, then re-flip in 6.7.0 / May — see DavMail RELEASE-NOTES). DavMail is *currently being patched in lock-step* with those changes; mbsync + a borrowed Thunderbird `client_id` + a hand-rolled `oauth2ms`-style helper would push that maintenance burden onto us. DavMail releases through April–May 2026 explicitly call out tracking Microsoft's behaviour, plus a brand-new Graph backend that will replace EWS before Microsoft's 2027 EWS shutdown ([Help Net Security 2026-04-14](https://www.helpnetsecurity.com/2026/04/14/davmail-6-6-0-released/), [SourceForge 6.7.0 news](https://sourceforge.net/p/davmail/news/2026/05/davmail-670-released/)).
+2. **DavMail has a first-class NixOS module already.** `services.davmail.{enable,url,config}` exists in nixpkgs (verified `unstable`, package version 6.5.1). Wiring the device-code one-shot bootstrap and persisting the encrypted refresh token through sops is straightforward. Architecture 1's path requires shipping `cyrus-sasl-xoauth2` + a custom token-refresher script per account and praying the borrowed Thunderbird `client_id` keeps working. Architecture 3 (headless TB in a container) reproduces the Windows-VM problem nearly verbatim.
+3. **mbsync is the strongest IMAP fetcher in 2026 — but for plain-IMAP, not OAuth on its own.** `getmail6` has unresolved IDLE+OAuth refresh bugs (issues #60 / #62, both still showing the failure mode where `IMAP IDLE` reconnects with a stale token). `OfflineIMAP3` had an O365 XOAUTH2 regression in Feb 2024 (issue #187) that mbsync did not. With a localhost DavMail bridge, mbsync only sees a plain IMAP server, so the brittle XOAUTH2 path inside the fetcher disappears entirely. For the Gmail account (where the user has their own OAuth client and Gmail's XOAUTH2 has been stable for years) mbsync + `cyrus-sasl-xoauth2` is the better path than running it through DavMail.
+
+**Why not Architecture 1 (mbsync + borrowed client_id direct to O365):** the Thunderbird client_id approach genuinely works *today* against the `common` tenant endpoint, but: (a) the August 2024 incident where Microsoft disabled the older `08162f7c-…` Thunderbird client_id ([email-oauth2-proxy issue #267](https://github.com/simonrob/email-oauth2-proxy/issues/267)) is the canonical failure mode and could happen to `9e5f94bc-…` at any time; (b) when Microsoft tightens the redirect-URI rules (as they did April 2026 ahead of May 2026 reverting), every mbsync user has to write a patch; DavMail users got a release. The whole point of paying for the extra component is shifting that maintenance to someone else.
+
+**Why not Architecture 3 (headless Thunderbird):** TB can run headless, but the export-to-Maildir path either requires the now-deprecated ImportExportTools NG add-on running on a TB instance with a real profile dir, or `birdtrayexport`-style poking at TB's mbox files — neither is cleaner than just landing mail in Maildir directly. You also keep the GUI-OAuth-flow problem.
+
+---
+
+## 2. Per-Architecture Findings
+
+### Architecture 1 — Direct IMAP fetcher with borrowed Thunderbird client_id
+
+**Solves no-app-registration in 2026?** Yes, conditionally. The current Thunderbird `client_id = 9e5f94bc-e8a4-4e73-b8be-63364c29d753` works against the `common` tenant endpoint with scopes `IMAP.AccessAsUser.All`, `offline_access`, `SMTP.Send` — confirmed by [Mozilla's own KB](https://support.mozilla.org/en-US/kb/microsoft-oauth-authentication-and-thunderbird-202) and [benswift.me 2025-09-12](https://benswift.me/blog/2025/09/12/the-great-2025-email-yak-shave-o365-mbsync-mu-neomutt-msmtp/) (a working 2025 guide using exactly this client_id with mbsync). For organisationally-managed tenants the Mozilla KB recommends admins visit `login.microsoftonline.com/{tenant}/adminconsent?client_id=…`, but for a tenant where the user only has their own mailbox and IMAP is enabled at the protocol level (the user's stated situation), individual user consent on the `common` endpoint is generally enough.
+
+**Operational fragility:** moderate-to-high. Specific failure modes:
+
+- **Client_id revocation.** Microsoft disabled the older Thunderbird client_id `08162f7c-0fd2-4200-a84a-f25a4db0b584` on **2024-08-01** ([email-oauth2-proxy issue #267](https://github.com/simonrob/email-oauth2-proxy/issues/267)). Mozilla rotated to `9e5f94bc-…`. There is no public commitment from Microsoft that this won't recur.
+- **Redirect-URI regime changes.** Microsoft changed allowed redirect URIs for native clients in March-April 2026; both DavMail and the email-oauth2-proxy needed releases. mbsync + a hand-rolled `oauth2ms` would also have needed editing.
+- **IDLE + token refresh.** `getmail6` has a documented bug (issues [#60](https://github.com/getmail6/getmail6/issues/60), [#62](https://github.com/getmail6/getmail6/issues/62)) where the IDLE reconnect loop reuses an expired access token and fails. Issue #62 has a linked PR (#63); current status as of May 2026 is unclear from the public record. mbsync doesn't natively IDLE — it polls or runs under `goimapnotify` — so mbsync sidesteps that specific bug, but we'd then need `goimapnotify` *also* to use OAuth, doubling the refresh-token plumbing.
+
+**NixOS friendliness:** medium. `isync` (1.5.1), `cyrus-sasl-xoauth2` (0.2), and `getmail6` (6.19.12) are all packaged in nixpkgs unstable. There is no NixOS module for either; you write a systemd service and timer yourself. `oauth2ms` / `mutt_oauth2.py` are not packaged — you'd ship them via `pkgs.writeScriptBin` or similar. Manageable but bespoke.
+
+**2026 health signal:**
+- isync 1.5.1 in nixpkgs; isync project itself is sleepy but stable — no concerning silence.
+- `cyrus-sasl-xoauth2`: low-activity but functioning.
+- getmail6 v6.19.10–6.19.12 released through 2025; latest 2026-08 per release feed. Active.
+- `oauth2ms` (harishkrupo/oauth2ms): largely unmaintained as a project; people copy-paste it.
+- Community signal in 2025 (Stanford, UWashington, ETHZ, multiple personal blogs) treats this stack as "works, but expect to tinker each year."
+
+**Verdict:** viable, lots of in-the-wild evidence, but you absorb every Microsoft auth-policy shift personally.
+
+### Architecture 2 — DavMail as O365 → IMAP bridge (RECOMMENDED)
+
+**Solves no-app-registration in 2026?** Yes. DavMail uses `O365Modern` / `O365Manual` / `O365DeviceCode` modes, all of which authenticate the *user* via Microsoft's standard interactive or device-code flow. It uses a published Microsoft client_id internally and persists an encrypted refresh token (`davmail.oauth.persistToken=true`) in its properties file after first login. No app registration in the work tenant.
+
+**Operational fragility:** low-to-medium. The key signal is: when Microsoft moved the redirect-URI goalposts in early 2026, DavMail shipped 6.6.0 in April fixing it, and the maintainer reverted in 6.7.0 in May after Microsoft re-flipped (live.com vs localhost). That responsiveness is exactly what we're paying for. Resource cost is one Java JVM (~150–250 MB RSS, idle); modest on doc2 (which has plenty of headroom).
+
+Weak points:
+- **Initial bootstrap requires interactive code-paste.** This is one-off per refresh-token rotation. Workflow: temporarily set `davmail.mode=O365Manual` (or `O365DeviceCode`), run `davmail` interactively, paste the device code into the browser, wait for refresh token to be appended to the properties file, capture that token, re-encrypt with sops, restore service mode. Documented in [SourceForge headless-mode thread](https://sourceforge.net/p/davmail/discussion/644056/thread/c89c682851/).
+- **Refresh tokens can in principle be revoked** by tenant admins or by long inactivity; in practice the Microsoft Graph offline_access lifetime is 90 days of inactivity / unlimited if used. We meet that easily with continuous polling. If the refresh token does get revoked, recovery is "re-bootstrap" — same as Arch 1.
+- **DavMail's Graph backend isn't yet production-ready** (per 6.7.0 release notes) but the EWS path remains the production default. Microsoft's EWS shutdown begins **2026-10-01** (tenant-by-tenant) with full retirement **2027-04-01** ([Mozilla's Thunderbird Exchange announcement, 2025-11](https://blog.thunderbird.net/2025/11/thunderbird-adds-native-microsoft-exchange-email-support/)). DavMail's roadmap pivots to Graph before then; we should plan to bump DavMail packages aggressively through late 2026.
+
+**NixOS friendliness:** high. `services.davmail.enable` exists; `services.davmail.url` and `services.davmail.config` (free-form attribute set written into the davmail properties file) are the two main knobs. We write the IMAP and refresh-token state into `services.davmail.config`. Sample option list confirmed via mcp-nixos: only three options (`enable`, `url`, `config`) — small surface area, easy to wrap.
+
+**2026 health signal:** strongly positive.
+- DavMail 6.7.0 — **2026-05-02** (released two days ago)
+- DavMail 6.6.0 — 2026-04-12
+- DavMail 6.5.1 — 2025-10-29
+- DavMail 6.5.0 — 2025-10-23 (FIDO2, Windows Hello, SWT WebView2)
+- DavMail 6.4.0 — 2025-08-31 (introduced experimental Graph backend)
+- DavMail 6.3.0 — 2025-02-26 (JRE 21, TLS 1.3 channel binding)
+
+That's **6 releases in 14 months**, with each one explicitly tracking Microsoft auth changes. Maintainer Mickaël Guessant continues to ship.
+
+The nixpkgs package lags slightly (unstable shows 6.5.1 — the late 2025 version) but the maintainer can override with a flake input or we can land a nixpkgs bump ourselves; cycle is normal for a Java desktop app.
+
+### Architecture 3 — Linux Thunderbird in a container
+
+**Solves no-app-registration in 2026?** Yes — TB uses the same `9e5f94bc-…` client_id as mbsync would, just inside a GUI. Same revocation risk.
+
+**Operational fragility:** high. You're running an interactive MUA without a human in front of it. OAuth re-prompts (which TB occasionally throws when access tokens fail mid-session) require a `xpra`/VNC session; refresh-token rotation requires the TB profile to be writable; and the Maildir export is a separate moving part:
+
+- Native TB stores in mbox by default, not Maildir. A profile preference (`mail.serverDefaultStoreContractID = "@mozilla.org/msgstore/maildirstore;1"`) switches this; not all add-ons cope.
+- ImportExportTools NG is the de-facto export add-on and its 2025 status is "still works, occasionally lags" — another moving part.
+
+The *only* reason to choose this path is if both Arch 1 and Arch 2 fail simultaneously, which would require Microsoft to make the borrowed-client_id approach unworkable AND DavMail's bridge to die. In that scenario, TB-in-a-container is also dead because TB uses the same approach.
+
+**NixOS friendliness:** low. You'd ship TB via `oci-containers` (rootful podman per the project's `homelab.podman` pattern), persistent volume for the profile, and an exporter sidecar (offlineimap pulling from TB? hardly cleaner than fetching directly). This is the worst NixOS story of the three.
+
+**2026 health signal:** TB itself is healthy (v145 added native Exchange/EWS in November 2025) but the *headless container TB* community is small. Few people do this on purpose.
+
+**Verdict:** rejected unless 1 and 2 both fail.
+
+---
+
+## 3. Specific Tool Comparison (within Architecture 1, also relevant for Gmail under Arch 2)
+
+| Tool | XOAUTH2 in 2026 | IDLE | nixpkgs | Refresh-token UX |
+| --- | --- | --- | --- | --- |
+| **mbsync (isync)** 1.5.1 | Works via `cyrus-sasl-xoauth2` SASL plug-in + `PassCmd` returning a fresh access token. Stable when wired correctly. AuthMechs XOAUTH2; Method tail | **No native IDLE.** Use `goimapnotify` to invoke mbsync on push, or systemd timer for poll. With O365's TLS overhead, 60s timer is fine. | Yes, `pkgs.isync` 1.5.1; `pkgs.cyrus-sasl-xoauth2` 0.2 | Helper script (oauth2ms / mutt_oauth2.py) refreshes each invocation; mbsync never sees a long-lived token. Robust. |
+| **getmail6** 6.19.12 | Has `use_xoauth2` option, documented for Gmail, used in the wild for O365. | **Native IDLE retriever exists**, but issues [#60](https://github.com/getmail6/getmail6/issues/60) and [#62](https://github.com/getmail6/getmail6/issues/62) document a token-refresh failure when the server invalidates the IDLE session at token expiry. | Yes, `pkgs.getmail6` 6.19.12 | Cached in-memory, *not refreshed on reconnect* — that's the bug. Workarounds exist; not pretty. |
+| **OfflineIMAP3** | XOAUTH2 supported; users hit a Feb 2024 regression with O365 ([issue #187](https://github.com/OfflineIMAP/offlineimap3/issues/187)). | No native IDLE. | Yes (`pkgs.offlineimap`) | Helper-script pattern same as mbsync. Heavier, slower than mbsync. |
+| **Davmail-bridged plain IMAP** (Arch 2) | N/A — bridge speaks plain IMAP. | mbsync poll against localhost is essentially free; no IDLE needed at all because the polling cost is negligible. | mbsync packaged. | Refresh-token lives in DavMail's encrypted properties file. mbsync never touches OAuth. |
+
+**Recommendation within the comparison:** **mbsync everywhere.** For Gmail (own OAuth client, stable), use `mbsync + cyrus-sasl-xoauth2 + PassCmd-of-a-token-refresher`. For O365 via DavMail, use `mbsync + plain login` against localhost. One fetcher, two configs, one set of operational habits.
+
+---
+
+## 4. MailStore Migration
+
+**What MailStore Home exports:**
+
+- Format: **EML** files (one per message), or MSG (Outlook). EML is RFC822 — exactly the byte stream we want in Maildir. Headers, body, attachments, dates all preserved (it's just the raw message envelope).
+- Folder hierarchy: preserved if the **"Retain folder structure"** checkbox is enabled — confirmed in MailStore's docs ([Exporting Email — MailStore Home Help](https://help.mailstore.com/en/home/Exporting_Email)).
+- Maildir export: **not directly supported.** EML-tree is the closest format and is trivially convertible.
+- Other relevant export targets that MailStore Home can do but we don't want: Outlook profile, IMAP server, MBOX. EML-to-directory is the only one that gives us per-message files cleanly.
+
+**Third-party tools that read MailStore's `.dat`/`.rr` directly:** none worth using. The format is proprietary; the only practical reader is MailStore Home itself. Don't go down that path — use the export.
+
+**Migration plan sketch:**
+
+1. **One-time:** install MailStore Home on the existing Windows VM (it's already there). Use `Export Email → File system, EML format → Retain folder structure` to dump the full archive to e.g. `\\doc2\share\mailstore-export\`. ~11 GB of EML files, no compression.
+2. **EML → Maildir conversion:** a ~30-line Python script using `mailbox.Maildir` and `email.parser`. For each `.eml`:
+   - Parse, extract `Message-ID` header (fallback: hash of first 4KB of message bytes as synthetic ID).
+   - Dedup by Message-ID against a set you build as you go.
+   - Reconstruct folder hierarchy as Maildir subfolders (`Maildir/.Folder.Subfolder/`).
+   - Write to `cur/` with a generated filename and `:2,S` suffix so mbsync treats them as already-seen.
+3. **Merge with live archive:** because mbsync is already populating `/mnt/data/Life/Andy/Email/<account>/` with new mail, just import the historical Maildir into the same tree but in a separate folder hierarchy *first* (e.g. `Archive.Historical.<original-folder>`). Then optionally run `maildir-deduplicate` ([PyPI](https://pypi.org/project/maildir-deduplicate/)) to drop any messages that live in both. Defer until you're certain the live mbsync run is stable; it's safer to have duplicates than gaps.
+4. **Retire MailStore:** once the Maildir tree is verified (count messages by year, spot-check a few attachments), `pveum vm destroy 102`. Wipe the EML export staging directory.
+
+**Fidelity caveat:** EML preserves the *message*, but MailStore-internal labels/tags/categories (if you used them — most home users don't) are not in the EML envelope. They were probably never written back to the source server either, so this is a non-issue for our use case.
+
+---
+
+## 5. Conditional Access Risk — Pre-Implementation Test
+
+**The risk:** even if Microsoft accepts the OAuth flow with Thunderbird's client_id, a tenant-level Conditional Access policy can still block the resulting IMAP session. Common policies that hit headless OAuth IMAP:
+
+- "Require multi-factor authentication" — usually OK for OAuth (MFA happens at consent), unless paired with "every N days" re-MFA on the resource.
+- "Require device to be marked as compliant" — fatal. Doc2 will not be Intune-managed.
+- "Block legacy authentication / 'Other clients'" — should be OK if our session uses XOAUTH2 (which it does), but some tenant configs misclassify XOAUTH2-IMAP as legacy.
+- "Authentication flows" condition (recent CA feature) — explicitly can block device-code flow ([Microsoft docs: policy-block-authentication-flows](https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-block-authentication-flows)).
+
+**Pre-implementation test (run this BEFORE building anything):**
+
+The cheapest probe is exactly what the eventual production stack does, but on a workstation:
+
+1. On a Linux box, install `davmail` from nixpkgs (or grab a release jar). Set `davmail.mode=O365Manual` and `davmail.url=https://outlook.office365.com/EWS/Exchange.asmx`.
+2. Run davmail. Configure a local mail client (or `openssl s_client` to localhost:1143) to fetch INBOX.
+3. Davmail will print a code and a URL. Visit, sign in, paste code.
+4. Outcomes:
+   - **Success:** mail starts flowing. CA is not in the way. Production path is safe.
+   - **Sign-in shows "Your organization needs to manage this device":** device-compliance CA. Architecture is dead until you can either get an exemption or use a different account.
+   - **Consent UI shows "needs admin approval" with no user-consent button:** the tenant has user-consent disabled. You'd need an admin to grant consent for `9e5f94bc-…` (the Thunderbird app used by DavMail under the hood, or whatever DavMail uses now — check at consent time). Pre-emptive fix: ask the tenant admin to grant tenant-wide consent for Thunderbird's app id. This is a single click and doesn't require any *new* app registration.
+   - **Authentication succeeds but `LIST` or `LOGIN` fails immediately on the IMAP side:** this is the "IMAP disabled at the protocol level" failure. The user's brief says IMAP is confirmed working today, so unlikely.
+5. **Bonus probe:** ask the tenant admin (or a trusted colleague who has admin) to dump the CA policy summary: in Entra Admin Center → Conditional Access → Policies, screenshot the matrix. Look for any policy that targets "Office 365" or "Exchange Online" and applies "Block" or "Require compliant device" without excluding `Other clients`.
+
+If the probe fails specifically on device-compliance, neither Arch 1 nor Arch 2 will save us. Arch 3 (TB-in-a-container) ALSO fails, because device-compliance keys off the device, not the app. In that scenario the only way forward is a tenant exemption or an alternative export channel (POP/IMAP from the user's Outlook desktop client to a local Dovecot — out of scope here).
+
+**Run the probe first.** It's 30 minutes of effort and tells you whether the project is viable before any module work.
+
+---
+
+## 6. Deduplication Strategy
+
+Maildir filenames are arbitrary; deduplication is by **`Message-ID` header**. Strategy when merging migrated archive against live mbsync output:
+
+1. **Keep the archive in a separate Maildir tree initially.** `/mnt/data/Life/Andy/Email/o365/` (live) and `/mnt/data/Life/Andy/Email/o365.archive/` (migrated). No collision possible.
+2. **Run `maildir-deduplicate` (Python, [PyPI](https://pypi.org/project/maildir-deduplicate/))** with `--strategy=delete-older`. It hashes Message-ID + a few fallback headers (Date, Subject, From) and removes duplicates. The "older" tiebreaker keeps the live-fetched copy — which we trust more because the migrated archive may have been re-encoded by MailStore.
+3. **Schedule the dedupe as a one-shot oneshot systemd unit**, gated behind a flag file you create after manual verification — not a recurring job. Once the merge is done, you don't want it running again because it would compete with live writes.
+4. **Worth knowing:** mbsync writes new messages to the `new/` subdir initially and moves them to `cur/` after the next sync. If you start a dedupe run mid-fetch, you can race. Stop mbsync during the merge.
+
+If you'd rather not import a third-party tool, the same logic in 50 lines of Python: walk both trees, map Message-ID → filepath, on collision keep the live one and `os.unlink` the archive one.
+
+---
+
+## 7. NixOS Module Sketch
+
+Following `.claude/rules/nixos-service-modules.md`. Two modules: `homelab.services.mailarchive` (top-level orchestrator) and lean wrappers around the upstream `services.davmail` plus mbsync. Keep DavMail's existing nixpkgs module; layer our concerns on top.
+
+**File:** `modules/nixos/services/mailarchive.nix`
+
+```nix
+{ config, lib, pkgs, ... }: let
+  cfg = config.homelab.services.mailarchive;
+  user = "mailarchive";
+in {
+  options.homelab.services.mailarchive = {
+    enable = lib.mkEnableOption "Continuous IMAP archival to Maildir";
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/mnt/data/Life/Andy/Email";
+      description = "Root for per-account Maildir trees.";
+    };
+    accounts = lib.mkOption {
+      description = "Mailbox accounts to archive.";
+      default = { };
+      type = lib.types.attrsOf (lib.types.submodule ({ name, ... }: {
+        options = {
+          provider = lib.mkOption {
+            type = lib.types.enum [ "gmail" "o365-davmail" ];
+          };
+          remoteUser = lib.mkOption { type = lib.types.str; };
+          # Path to a sops secret. Format depends on provider:
+          #   gmail:        OAuth refresh-token (used by mbsync PassCmd helper)
+          #   o365-davmail: localhost auth password (mbsync uses plain LOGIN against davmail)
+          credentialSecret = lib.mkOption { type = lib.types.str; };
+          syncIntervalSec = lib.mkOption {
+            type = lib.types.int;
+            default = 60;
+          };
+        };
+      }));
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.${user} = {
+      isSystemUser = true;
+      group = user;
+      home = cfg.dataDir;
+      createHome = false;
+    };
+    users.groups.${user} = { };
+
+    # -- DavMail (one instance, handling all O365 accounts via per-account OAuth state)
+    services.davmail = lib.mkIf (lib.any (a: a.provider == "o365-davmail")
+                                         (lib.attrValues cfg.accounts)) {
+      enable = true;
+      url = "https://outlook.office365.com/EWS/Exchange.asmx";
+      config = {
+        davmail.mode = "O365Modern";        # after bootstrap; "O365Manual" for first run
+        davmail.imapPort = 1143;
+        davmail.bindAddress = "127.0.0.1";
+        davmail.allowRemote = false;
+        davmail.oauth.persistToken = true;
+        davmail.disableUpdateCheck = true;
+        # Per-account refresh tokens injected via systemd EnvironmentFile from sops:
+        # davmail.oauth.<user@tenant>.refreshToken={AES}...
+      };
+    };
+
+    # -- Per-account mbsync configs and timers
+    systemd.tmpfiles.rules = lib.flatten (lib.mapAttrsToList (n: a: [
+      "d ${cfg.dataDir}/${n}                0700 ${user} ${user} -"
+      "d ${cfg.dataDir}/${n}/Maildir        0700 ${user} ${user} -"
+    ]) cfg.accounts);
+
+    environment.etc = lib.mapAttrs' (n: a: lib.nameValuePair
+      "mailarchive/mbsync-${n}.rc" {
+        mode = "0400";
+        user = user; group = user;
+        text = mkMbsyncrc { inherit n a cfg; };
+      }) cfg.accounts;
+
+    systemd.services = lib.mapAttrs' (n: a: lib.nameValuePair
+      "mailarchive-${n}" {
+        description = "Mail archive sync: ${n}";
+        path = with pkgs; [ isync cyrus-sasl-xoauth2 ];
+        serviceConfig = {
+          Type = "oneshot";
+          User = user;
+          EnvironmentFile = config.sops.secrets."mailarchive/${n}".path;
+          ExecStart = "${pkgs.isync}/bin/mbsync -c /etc/mailarchive/mbsync-${n}.rc -a";
+          Nice = 10;
+        };
+        # Restart davmail-coupled accounts whenever davmail's unit changes.
+        restartTriggers = lib.optional (a.provider == "o365-davmail")
+          config.systemd.units."davmail.service".unit;
+      }) cfg.accounts;
+
+    systemd.timers = lib.mapAttrs' (n: a: lib.nameValuePair
+      "mailarchive-${n}" {
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          OnBootSec = "2min";
+          OnUnitActiveSec = "${toString a.syncIntervalSec}s";
+          AccuracySec = "10s";
+        };
+      }) cfg.accounts;
+
+    # -- Sops secrets layout
+    sops.secrets = lib.mapAttrs' (n: a: lib.nameValuePair
+      "mailarchive/${n}" {
+        sopsFile = config.homelab.secrets.sopsFile "mailarchive-${n}.env";
+        format = "dotenv";
+        owner = user; mode = "0400";
+      }) cfg.accounts;
+
+    # Plus a separate secret with davmail's per-account refresh tokens, owned by davmail user
+    sops.secrets."mailarchive/davmail-tokens" = lib.mkIf
+      (lib.any (a: a.provider == "o365-davmail") (lib.attrValues cfg.accounts)) {
+        sopsFile = config.homelab.secrets.sopsFile "davmail-oauth.env";
+        format = "dotenv";
+        owner = "davmail"; mode = "0400";
+      };
+
+    # -- Reverse proxy: not needed (no external surface)
+    # -- Monitoring
+    homelab.monitoring.monitors = lib.flatten (lib.mapAttrsToList (n: _: [{
+      name = "Mailarchive: ${n}";
+      # Push-style: a successful mbsync run touches a heartbeat file; a tiny
+      # http endpoint on localhost serves its mtime delta. See uptime-kuma push monitors.
+      type = "push";
+      pushInterval = 600;  # alert if no sync in 10 minutes
+    }]) cfg.accounts);
+
+    # -- NFS watchdog (dataDir is on /mnt/data which is virtiofs; treat like NFS)
+    homelab.nfsWatchdog.mailarchive.path = cfg.dataDir;
+  };
+}
+```
+
+**Host enablement** (`hosts/doc2/configuration.nix`):
+
+```nix
+homelab.services.mailarchive = {
+  enable = true;
+  dataDir = "/mnt/data/Life/Andy/Email";
+  accounts = {
+    gmail = {
+      provider = "gmail";
+      remoteUser = "abl030@gmail.com";
+      credentialSecret = "mailarchive/gmail";
+      syncIntervalSec = 120;
+    };
+    work = {
+      provider = "o365-davmail";
+      remoteUser = "<work-email>";
+      credentialSecret = "mailarchive/work";
+      syncIntervalSec = 60;   # tighter — we delete fast
+    };
+  };
+};
+```
+
+**Sops secret layout (`secrets/hosts/doc2/`):**
+
+- `mailarchive-gmail.env` — `MBSYNC_PASS=<output-of-oauth2-helper>` plus `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `OAUTH_REFRESH_TOKEN` for the Gmail PassCmd helper.
+- `mailarchive-work.env` — `MBSYNC_PASS=<davmail-localhost-passphrase>` (DavMail uses the user's Microsoft password as the IMAP login password OR a configurable static value; check DavMail's `davmail.imapAuth` setting).
+- `davmail-oauth.env` — environment-file fragment containing `davmail.oauth.<user>.refreshToken=...` style lines, sourced by the davmail systemd unit.
+
+**Two helper bits worth flagging:**
+
+1. The Gmail PassCmd helper: ship as a small `pkgs.writeShellApplication` calling Python's `msal` or `requests` to swap the refresh token for a fresh access token, print it, exit. mbsync calls this every sync.
+2. DavMail bootstrap: a separate documented one-time procedure (`docs/runbooks/mailarchive-bootstrap.md`) that flips davmail to `O365Manual`, runs it, captures the refresh token from the properties file, encrypts it into sops, then restores `O365Modern`.
+
+---
+
+## 8. Open Questions
+
+These need user verification before / during implementation:
+
+1. **Does the work tenant block device-code flow?** Run the pre-implementation test in section 5. If yes, the project is dead — escalate to user.
+2. **Does the work tenant require admin consent for `9e5f94bc-…` (Thunderbird) or DavMail's internal client_id?** DavMail's modern auth flows use Microsoft-published client_ids. If the consent UI says "needs admin approval," the user needs to ask the tenant admin to grant tenant-wide consent — single click, no new app registration.
+3. **What is DavMail's IMAP auth password?** DavMail can either pass through Microsoft passwords (won't work — we have no password, we have OAuth) or accept a configurable static value (`davmail.imapAuth=...`). Verify in the davmail.properties reference. Affects what we put in `MBSYNC_PASS`.
+4. **Does the existing MailStore archive include sent mail and IMAP-server-side folders that no longer exist on the live server?** If yes, the archive contains historical data the live fetch will never produce — keeping the migrated tree separate (section 6 step 1) becomes mandatory, not optional.
+5. **Is `/mnt/data/Life/Andy/Email/` on the same virtiofs mount as other doc2 state?** Confirm before turning on the NFS watchdog at that path; if it's a different mountpoint, pick the right one.
+6. **Where should the heartbeat-monitor live?** The Uptime Kuma push pattern in the sketch is hand-wavy. May be cleaner to switch to an active probe: a tiny script on doc2 that touches a file on each successful mbsync run, and a Kuma "Keyword" monitor that hits a localhost endpoint serving the mtime delta. Defer concrete design to ce-plan.
+7. **How will EWS-shutdown affect us in late 2026?** DavMail's Graph backend is "experimental" as of 6.7.0. We'll likely need to bump DavMail across the rest of 2026 and may hit breaking changes when the maintainer flips the default backend. Plan for one DavMail bump every 2-3 months minimum through 2027.
+8. **What does the Conditional Access policy review actually look like for the user?** They have "limited admin access" per the brief — does that include enough to view CA policies in the Entra admin center? If not, the probe in section 5 is the only practical way to discover policy effects.
+
+---
+
+## Source Map
+
+Key URLs cited above, grouped:
+
+**Microsoft auth landscape (2025–2026):**
+- [Mozilla Thunderbird OAuth KB (admin consent + scopes)](https://support.mozilla.org/en-US/kb/microsoft-oauth-authentication-and-thunderbird-202)
+- [Mailbird — Email Client Compatibility Crisis 2025-2026](https://www.getmailbird.com/email-client-compatibility-crisis-third-party-guide/)
+- [Mailbird — Modern Authentication Enforcement in 2026](https://www.getmailbird.com/microsoft-modern-authentication-enforcement-email-guide/)
+- [TB Knowledgebase issue #122 — admin enablement page request](https://github.com/thunderbird/knowledgebase-issues/issues/122)
+- [TB Blog — Native Exchange support, Nov 2025](https://blog.thunderbird.net/2025/11/thunderbird-adds-native-microsoft-exchange-email-support/)
+- [Microsoft Learn — Block authentication flows with CA](https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-block-authentication-flows)
+- [Microsoft — SMTP basic-auth deprecation timeline](https://techcommunity.microsoft.com/blog/exchange/updated-exchange-online-smtp-auth-basic-authentication-deprecation-timeline/4489835)
+
+**Thunderbird client_id revocation history:**
+- [email-oauth2-proxy issue #267 — older client_id disabled 2024-08-01](https://github.com/simonrob/email-oauth2-proxy/issues/267)
+- [TB Bugzilla #1685414 — Confidential vs Public Client](https://bugzilla.mozilla.org/show_bug.cgi?id=1685414)
+
+**DavMail health & releases:**
+- [DavMail RELEASE-NOTES.md (master)](https://github.com/mguessan/davmail/blob/master/RELEASE-NOTES.md)
+- [DavMail 6.6.0 release news (2026-04)](https://sourceforge.net/p/davmail/news/2026/04/davmail-660-released/)
+- [DavMail 6.7.0 release news (2026-05)](https://sourceforge.net/p/davmail/news/2026/05/davmail-670-released/)
+- [Help Net Security — DavMail 6.6.0 coverage](https://www.helpnetsecurity.com/2026/04/14/davmail-6-6-0-released/)
+- [DavMail FAQ](https://davmail.sourceforge.net/faq.html)
+- [DavMail headless / persistToken thread](https://sourceforge.net/p/davmail/discussion/644056/thread/c89c682851/)
+
+**mbsync/getmail6/offlineimap stack:**
+- [Arch Wiki — isync](https://wiki.archlinux.org/title/Isync)
+- [benswift.me 2025 yak-shave (mbsync + O365)](https://benswift.me/blog/2025/09/12/the-great-2025-email-yak-shave-o365-mbsync-mu-neomutt-msmtp/)
+- [Simon Dobson — mbsync + O365 OAuth 2024](https://simondobson.org/2024/02/03/getting-email/)
+- [getmail6 issue #60 — token refresh on IDLE reconnect](https://github.com/getmail6/getmail6/issues/60)
+- [getmail6 issue #62 — IDLE + OAuth unhandled exceptions](https://github.com/getmail6/getmail6/issues/62)
+- [offlineimap3 issue #187 — XOAUTH2 LIST regression Feb 2024](https://github.com/OfflineIMAP/offlineimap3/issues/187)
+- [moriyoshi/cyrus-sasl-xoauth2](https://github.com/moriyoshi/cyrus-sasl-xoauth2)
+- [harishkrupo/oauth2ms](https://github.com/harishkrupo/oauth2ms)
+- [UvA-FNWI/M365-IMAP — refresh-token helper](https://github.com/UvA-FNWI/M365-IMAP)
+
+**Nixpkgs:**
+- [nixos/modules/services/mail/davmail.nix (master)](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/mail/davmail.nix)
+- mcp-nixos confirmations for `davmail` (6.5.1), `isync` (1.5.1), `cyrus-sasl-xoauth2` (0.2), `getmail6` (6.19.12) on `unstable`.
+
+**MailStore migration:**
+- [MailStore Home — Exporting Email](https://help.mailstore.com/en/home/Exporting_Email)
+- [maildir-deduplicate on PyPI](https://pypi.org/project/maildir-deduplicate/)

--- a/docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan-REVIEW-2.md
+++ b/docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan-REVIEW-2.md
@@ -1,0 +1,159 @@
+# Plan Re-Review (Round 2): Mailarchive / Mailstore VM Retirement
+
+**Reviewer:** independent agent (round 2)
+**Date:** 2026-05-04
+**Plan reviewed:** docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan.md (revised)
+**Round 1 review:** docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan-REVIEW.md
+
+## Summary
+
+The rewrite is a substantial improvement: every C-class issue from round 1 is decisively fixed, all 9 S-class items are addressed (8 cleanly, 1 with a small remnant), and the user's three explicit directives (drop the parallel run, single mixed legacy tree, explicit folder selection) are all reflected. Two genuinely new issues emerged: (1) the plan asserts `pkgs.python3Packages.maildir-deduplicate` is available in nixpkgs unstable — it is **not** (verified via mcp-nixos; only a Perl `MailMaildir` and unrelated dedup tools exist), so U7c needs a different tool or an inline fallback; (2) U7c's smoke-test step "delete a test message from the live server, confirm Maildir copy stays" is tautological under `Sync Pull` + `Remove None` (mbsync never propagates remote deletes regardless of timing) — the test confirms the configuration matches the rc but doesn't exercise the deletion-resistance contract meaningfully. A handful of smaller items (PassCmd quoting, bootstrap chicken-and-egg, OAUTH_TENANT default consistency) deserve a sentence each. With those fixes the plan is ready.
+
+## Round-1 Findings — Verification Status
+
+| ID | Finding | Status | Notes |
+|----|---------|--------|-------|
+| C1 | json-query operator | Fixed | Plan line 97 (Key Technical Decisions) and U4 (lines 333-353) consistently use server-side boolean (`$.healthy == "true"`). No leftover `<600` comparator in the plan. The 600s threshold is preserved server-side as `STALE_THRESHOLD_SEC`. The risk row about `==` operator is gone (correctly, since that's no longer the failure mode). |
+| C2 | U6 wrong host | Fixed | Plan U6 (line 426) and U8 step 3 (line 513) both use `github:abl030/nixosconfig#doc2 --refresh` and `ssh doc2 "..."`. The U8 fixup paragraph "wait, doc2 is `doc2`, not `proxmox-vm`" is gone. ASCII-art bootstrap block at line 187 also says `#doc2`. Clean. |
+| C3 | Maildir layout | Fixed | U3 (line 285) and U7b (line 461) both explicitly state `SubFolders Verbatim` with nested directories. U7b's "Approach" bullet now reads "Reconstruct folder hierarchy as **nested Maildir directories** matching `SubFolders Verbatim`" and explicitly says "**Do not** flatten using Maildir++ dot-separated names". Key Technical Decisions section (line 96) reinforces the choice fleet-wide. |
+| S1 | vms/definitions.nix | Fixed | U8 step 8 (line 522) and the Documentation/Operational Notes (line 576) both correctly state "VM 102 was never inventoried" and call out CLAUDE.md's stale "Important Files" line as a separate optional cleanup. The verification block doesn't reference vms/definitions.nix. Verified `vms/definitions.nix` does not exist on disk. |
+| S2 | /mnt/data is NFS not virtiofs | Fixed | Summary (line 13), Key Technical Decisions (line 99), Context bullet (line 63), and System-Wide Impact (line 545) all say "NFSv4.2 to tower / Unraid". One borderline phrasing remains — Risks table line 565 says "/mnt/data NFS goes stale" which is now consistent. /mnt/virtio is correctly disambiguated as the virtiofs mount. |
+| S3 | mbsync direction Pull only | Fixed | Key Technical Decisions (line 91) and U3 (line 286) both lock in `Sync Pull`, `Create Near`, `Remove None`, `Expunge None`. The risk row at line 561 explicitly cites the test that verifies one-way semantics (no upstream pollution). Strong fix. |
+| S4 | Gmail patterns | Fixed | Plan line 94 (decisions) and U3 (line 288) both narrow Gmail to `Patterns "[Gmail]/All Mail"` only with explicit rationale (label-vs-folder duplication). U3's integration test (line 311) verifies total Maildir message count matches All-Mail count. |
+| S5 | Kuma co-location documented | Fixed | System-Wide Impact section adds a dedicated "Hidden constraint — Kuma host co-location" paragraph (line 550) and Risks table line 568 references the same constraint with a fallback. Honest framing — accept and document, swap to FQDN if Kuma ever moves. |
+| S6 | .sops.yaml edit removed | Fixed | U1's "Files" section (line 205) only lists `mailarchive.nix` create + `default.nix` modify. No mention of `secrets/.sops.yaml`. Clean. |
+| S7 | Inbox directive removed | Fixed | U3 (line 285) explicitly states: "Do **not** set an explicit `Inbox` directive — Verbatim defaults handle it under `Path`." |
+| S8 | SASL_PATH env var | Fixed | Key Technical Decisions (line 95) names `SASL_PATH=${pkgs.cyrus-sasl-xoauth2}/lib/sasl2` and U3 (line 291) wires it via `serviceConfig.Environment`. The risk row at line 562 cites the verification step (`mbsync -V` listing XOAUTH2). |
+| S9 | U7c sequencing | Fixed | U7's Dependencies line (line 450) now reads "U7c (optional dedup) is independent of U8" — no parallel-run gate. U7c body (line 466) recommends keeping legacy and live separate by default. Sequencing is sound now that the parallel-run is gone. |
+
+## New Critical Issues (must-fix before implementation)
+
+### N-C1. `maildir-deduplicate` is NOT packaged in nixpkgs (round 1's claim was wrong; the rewrite codified it)
+
+The plan's Open Questions (line 117) and U7c approach (line 466) both assert:
+> `maildir-deduplicate` available as `pkgs.python3Packages.maildir-deduplicate` in nixpkgs unstable
+
+Verified via mcp-nixos (`info` action, exact attribute path):
+> `Error (NOT_FOUND): Package 'python3Packages.maildir-deduplicate' not found`
+
+Broader search (`maildir-deduplicate` and `mail-deduplicate` queries) returned 20 unrelated results: `backdown`, `mb2md`, `mu`, `muchsync`, `getmail6`, `notmuch`, etc. — but no `maildir-deduplicate` or `mail-deduplicate` Python package. The closest is `perl5Packages.MailMaildir` (a different library entirely). The PyPI tool `maildir-deduplicate` (now renamed to `mail-deduplicate`) exists upstream but has not been packaged for nixpkgs.
+
+This propagates a round-1 nit (line 152 of REVIEW.md, "easy check: it's available as `pkgs.python3Packages.maildir-deduplicate`") that was itself unverified. The plan now treats the existence as resolved when it's not.
+
+**Fix options (any one is fine, since U7c is optional):**
+- Drop U7c's automated dedup and document a manual approach (fall back to a small inline Python script using `email.parser.BytesParser` + Message-ID set, ~30 lines, stdlib only). This matches the research doc's section 6 fallback ("the same logic in 50 lines of Python").
+- Package `mail-deduplicate` into the flake as a dev dependency via `nix-shell` or `pkgs.python3.withPackages` reading from `pip`/`builtins.fetchPyPI`. Adds friction.
+- Swap U7c to suggest `muchsync` or `mu`'s built-in dedup (both packaged) — different semantics; needs investigation.
+
+The plan's "default recommendation" already says "leave separate" (line 466) which is the lowest-risk path, so just removing the `maildir-deduplicate` claim and pointing at the inline-Python fallback closes the issue without architectural change.
+
+## New Should-Fix Issues
+
+### N-S1. U8 step 4 deletion-resistance test is tautological under `Sync Pull` + `Remove None`
+
+U8 step 4 (line 517):
+> Delete one of the test messages from the live server (OWA / Gmail web). Wait one more sync cycle. Confirm the Maildir copy stays put — this is the deletion-resistance load-bearing test.
+
+mbsync with `Sync Pull` + `Remove None` + `Expunge None` will **never** propagate remote deletes downward, regardless of when the delete happens. The Maildir copy stays whether you delete the test message before or after the next sync cycle. The "wait one more sync cycle" framing implies there's a race or window the test is exercising, but there isn't one. This test confirms the rc was applied correctly, but is identical to inspecting the rc file with `cat`.
+
+A more meaningful deletion-resistance test would verify:
+1. **The mbsync state file (`SyncState`) doesn't track the remote delete and re-fetch in a way that creates a duplicate**, OR
+2. **A new mbsync run after the delete still completes successfully** (regression: a misconfigured rc could fail on missing UIDs).
+
+Better wording: "Delete one of the test messages from the live server. Run mbsync once more (`systemctl start mailarchive-work.service`). Confirm: (a) the service exits 0, (b) the Maildir copy is untouched, (c) journalctl doesn't show 'message lost' or 'UID gap' errors. Repeat after a few hours to ensure incremental sync handles the gap." The test still passes under `Sync Pull` + `Remove None`, but it now exercises mbsync's state-tracking, not just the layout.
+
+Round 1 didn't catch this; my fault. Worth fixing.
+
+### N-S2. U-ID renumbering: U9 is dropped without a gap (against plan template stability rule)
+
+The instructions note that the plan template's stability rule says "deletion leaves a gap; gaps are fine." Per round 1's REVIEW.md (line 138, "U9: Document refresh-token rotation runbook"), the original plan had U1-U9. The rewrite consolidated U9 into U6 (per U6's body at line 411: "This doc consolidates U6 + U9").
+
+But the rewrite renumbered: the new plan now has U1-U8 with the OAuth bootstrap as U6 and the migration as U7 — there is no gap at U9. Cross-reference: the original plan's "U7. MailStore migration" would have stayed U7 if gaps were honored, and U8/U9 should have remained as VM retirement and runbook respectively. Looking at the rewrite's U7 (line 444) and U8 (line 487), the migration stayed U7 and VM retirement stayed U8 — which is consistent with the original numbering, IF the original plan also had U7=migration and U8=VM retirement. I don't have the original plan in front of me to verify the original numbering.
+
+If the original plan had: U1=skeleton, U2=helper, U3=mbsync, U4=monitor, U5=watchdog, U6=bootstrap, U7=migration, U8=enable+retire, U9=rotation runbook — then the rewrite correctly absorbs U9 into U6's doc and the gap convention is satisfied (U-IDs U1-U8 stable, U9 omitted). The new plan does match this numbering. **Verdict: probably fine, but explicitly call out "U9 is intentionally absorbed into U6 — no renumbering" in U6's preamble or in the section header so future reviewers don't have to reconstruct the history.**
+
+### N-S3. Bootstrap chicken-and-egg in U6 not addressed
+
+U6 (line 422):
+> On any machine with `nix-shell`, run `nix-shell -p mailarchive-helper --run 'oauth2-helper bootstrap --provider=gmail --user=<email>...'`
+
+But the helper (`oauth2-helper`) is defined inside the `mailarchive.nix` module's `let` block (per U2's approach, line 241) as a `pkgs.writers.writePython3Bin`. That makes it a derivation reachable from inside the module evaluation, not a top-level attribute named `mailarchive-helper` that `nix-shell -p` can find. A junior implementer following U6 verbatim will get "attribute 'mailarchive-helper' missing".
+
+The bootstrap is a chicken-and-egg situation: the helper has to be invokable before the module is enabled (so the user can paste the resulting refresh token into sops, then deploy). Three resolutions:
+
+1. **Expose the helper as a top-level flake app or package** (`packages.x86_64-linux.mailarchive-helper`). Then `nix run .#mailarchive-helper -- bootstrap ...` works from any clone of the repo. Cleanest.
+2. **Define the helper as a top-level package outside the module**, and reference it from the module's `let` block. Same pattern as `tools/podcast-fetcher` if such existed.
+3. **Document running the helper directly via `nix-build` against a known store path** — fragile.
+
+Option 1 matches the project's existing pattern (the `nix run .#fmt-nix` / `nix run .#lint-nix` apps mentioned in CLAUDE.md). Plan should explicitly say "the helper is exposed as `packages.x86_64-linux.mailarchive-helper` so `nix run .#mailarchive-helper -- bootstrap ...` works on any machine with a clone."
+
+This bug doesn't surface until U6 is actually executed, but the plan's bootstrap workflow assumes a packaging pattern not yet specified.
+
+### N-S4. `OAUTH_TENANT` default inconsistency between probe and helper
+
+The probe (`docs/brainstorms/2026-05-04-mailstore-vm-probe-result.md` line 99) used the `/common/` endpoint with `login_hint`-based tenant routing. The plan's U2 (line 245) says "for O365 also `OAUTH_TENANT` (default `common`)". The probe also captured the actual tenant ID `32bffe65-3e64-414f-9d21-069572b800eb` (probe result line 83).
+
+Both work — `/common/` plus `login_hint=user@cullenwines.com.au` routes correctly. The user gains nothing concrete by hardcoding the tenant ID. But once the user is locked to one tenant (work O365), there is a small operational reason to prefer the tenant-specific endpoint: failed routing produces clearer error messages, and a tenant rename or migration would surface as an explicit refresh failure rather than silent rerouting.
+
+Either default is defensible. Just be explicit: pick one and document why. Currently the plan defaults to `common` (per U2 line 245), which matches the probe. That's fine — but say so explicitly in U6's runbook: "OAUTH_TENANT defaults to `common` per probe; override only if you hit tenant-routing errors."
+
+### N-S5. mbsync `PassCmd` shell-quoting under Nix interpolation is unaddressed
+
+U3's mbsync rc snippet (line 283):
+```
+PassCmd "${oauth2-helper}/bin/oauth2-helper refresh --provider=${provider}"
+```
+
+mbsync's `PassCmd` invokes the value via `popen()` — it's a shell command. The Nix interpolation produces an absolute store path like `/nix/store/xxx-mailarchive-helper/bin/oauth2-helper`. Store paths never contain spaces or special shell characters (Nix sanitizes), so no escaping is needed for the path itself. `${provider}` interpolates `gmail` or `o365` — also safe.
+
+**Verdict:** the quoting is fine in practice for these specific values. But the plan should note this assumption explicitly: "PassCmd's value is shell-evaluated; Nix store paths never contain shell metacharacters, so `${...}` interpolation is safe here. If the provider enum is ever extended to a value containing spaces/quotes, escape or pass via env." One sentence in U3's approach. Round 1 missed this; called out for completeness.
+
+## New Nits
+
+- **mbsync `Patterns` syntax with quoted folder names containing spaces.** The plan's O365 patterns include `"Sent Items*"`, `"Deleted Items*"`, `"Junk Email"` — all quoted, all containing spaces. mbsync's pattern syntax (per `man mbsync`) accepts double-quoted strings; spaces inside quotes are part of the pattern. This is correct usage. No fix needed, just confirming the syntax is valid (round 1 didn't verify, my responsibility to confirm: confirmed).
+- **`Archive` (singular, no asterisk) in O365 patterns is leftover.** Probe output showed `Archives` (plural, with `Archives/2024`, `Archives/2025` children) but no `Archive` (singular) folder. The plan lists both `"Archive" "Archives*"` (line 209). `Archives*` matches `Archives` itself plus children; `Archive` singular is dead pattern. Either drop it, or — if the intent is to be defensive against tenants that use `Archive` (singular, common in some Outlook configurations) — leave it and note "matches if user has a singular Archive folder; harmless otherwise." A one-word annotation suffices.
+- **`STALE_THRESHOLD_SEC` (server-side) and `interval × maxretries` (client-side) are complementary, not redundant.** The plan has both gates: `STALE_THRESHOLD_SEC = 600s` flips `healthy` to `false`; then Kuma's `interval=60s × maxretries=10 = 600s` adds another 10 minutes of confirmation before paging. Total worst case before Gotify: ~20 minutes. This is by design — server-side gate preserves health endpoint accuracy (so a `curl` shows true state); client-side gate suppresses transient 404s/502s/etc. The plan's U4 approach (line 352) almost says this but could state it more directly: "Server-side threshold suppresses heartbeat-clock-skew false positives; Kuma's retry window suppresses HTTP-server-blip false positives. Both gates together yield ~10-20 min before page; that's intentional." Clarify or accept.
+- **`docs/runbooks/` reference removed; runbook lives at `docs/wiki/services/mailarchive.md`.** Verified — line 418, 574 both reference the wiki path. Round 1 nit closed.
+- **The cleaned-up `Mailstore-export/` path is documented in U7a (line 457) as `_mailstore-export-staging/` and referenced in U8 step 8 (line 522).** Round 1 nit ("pick one canonical path") satisfied.
+- **`vms/proxmox-ops.sh` supports `stop` and `destroy`.** Verified by grepping the wrapper: lines 352-364 of the script include `stop)`, `destroy)`, `list)`. The plan's U8 (lines 519, 521, 525) correctly calls `vms/proxmox-ops.sh stop 102` / `destroy 102` / `list`. Round 1 instruction-level concern addressed; no extension needed.
+- **Bootstrap eventual-consistency callout strengthened.** U6 step 6 (line 427) reads: "**The very first `mailarchive-*.service` run after bootstrap may fail with `AUTHENTICATE failed` in the journal. This is *expected* — Microsoft's auth-issuer and Exchange Online's IMAP service have a few-minute consistency lag on first-auth. Do **not** re-run the bootstrap. Wait 5 minutes; the next timer fire will succeed.**" Bolded twice, "do not re-run" emphasized. Strong fix; round 1 nit closed.
+- **`runAsRoot` correctly omitted, `restartTriggers` correctly omitted.** The plan's calibration on what to skip from the kopia pattern is clean. No change needed.
+- **U3's `path = with pkgs; [ isync coreutils ]` simplification suggestion.** Round 1 line 126 noted that `path` only sets `$PATH`, not LD_LIBRARY_PATH. The rewrite uses `path` to expose `isync` and `coreutils` (so `mbsync` and `touch` are on `$PATH` — making the `ExecStart` and `ExecStartPost` strings shorter). Alternative would be absolute paths (`${pkgs.coreutils}/bin/touch`), as the prompt notes. Both work; the rewrite's choice is fine and idiomatic. No fix needed.
+
+## User-Directive Verification
+
+- (yes) **2-week parallel run removed.** Plan Summary (line 13) says "Smoke-test the live fetch with a few real messages, then stop and destroy VM 102 with a short safety window." U8 (line 487) goal: "smoke-test against real messages, stop VM 102, and destroy it after a short safety window." U8 step 6 (line 520) says "Wait ~3-5 days with VM 102 stopped." U8 test expectation (line 534): "No '2-week parallel run' — once smoke test passes and the safety window elapses, retirement proceeds." Strong, explicit removal across multiple sections.
+- (yes) **Mixed Gmail+O365 archive treated as single legacy tree.** Summary (line 13): "Migrate the 11 GB existing MailStore Home archive (mixed Gmail + O365, single repository) into a one-shot `legacy.archive/` Maildir tree." Key Technical Decisions (line 101) and U7 goal (line 444) both reinforce. Scope Boundaries → Deferred (line 52) explicitly marks per-account split as a separate future script.
+- (yes) **Sent Items + meaningful folders explicitly archived.** Plan line 93 (Key Technical Decisions): "O365: explicit folder set — `Patterns 'INBOX*' 'Sent Items*' 'Archive' 'Archives*' 'Drafts' 'Deleted Items*' 'Junk Email'`. Captures everything the user actively organises ... excludes `Calendar`, `Contacts`, `Tasks`, `Notes`, `Sync Issues`, `Conversation History`, `Outbox`, `RSS Feeds`, `Templates` which are calendar/state folders not mail." Folder selection is **explicit**, not implicit. U6 step 3 (line 424) makes the user re-confirm before deploy.
+- (yes) **All round-1 issues addressed (or explicit reason for partial fixes).** All 12 round-1 items (3 critical + 9 should-fixes) are accounted for above; only minor remnants noted in N-S2, none unaddressed.
+
+## Strengths Worth Preserving
+
+- **Clean separation of concerns in module options.** `accounts = attrsOf submodule` + `provider = enum` is the right shape; doesn't repeat `kopia`'s slight option bloat.
+- **Per-instance systemd timer-driven oneshot** correctly omits `restartTriggers` (no DB container) and correctly omits `runAsRoot` (mailarchive owns its own Maildir).
+- **Server-side threshold + Kuma client-side retry as complementary gates** is good monitoring discipline. Both gates pull in the same direction (suppress false positives without delaying real alerts much).
+- **Hidden-constraint documentation around localhost monitor URL.** The plan being honest about a fleet-wide constraint instead of papering over it is good agent-archaeology hygiene.
+- **U6 absorbs U9's content cleanly** (line 429 — token-rotation + client_id-revocation recovery is in the same wiki doc as bootstrap). One operational doc, not two.
+- **mbsync rc semantics locked down** (`Sync Pull`, `Create Near`, `Remove None`, `Expunge None`, no explicit `Inbox`, `SubFolders Verbatim`) with each choice justified in Key Technical Decisions. Future implementer can't accidentally pick a "two-way sync" rc.
+- **Migration treats legacy and live as separate trees by default** with optional dedup. Lower-risk default; matches research doc section 6 step 1.
+- **Probe trio remains the source of truth** — Sources & References cite the requirements, research, probe, and now the round-1 review explicitly.
+
+## Open Questions for the Author
+
+1. **Where does the helper actually surface for `nix run`?** See N-S3. The bootstrap workflow assumes the helper is invokable before the module is enabled; the packaging pattern needs to be one of: top-level flake app, top-level package, or explicit nix-shell/nix-build invocation. Not yet specified.
+2. **U7c when `maildir-deduplicate` isn't packaged.** See N-C1. If the user wants the optional dedup, what's the fallback? Inline Python is the lowest-friction answer.
+3. **Does U8's "delete-test on live server" actually exercise anything beyond the rc?** See N-S1. If not, replace with a more meaningful test of mbsync's state file behavior across UID gaps.
+4. **Will the user actually want the smoke-test gate in front of VM 102 destruction to be 3-5 days, or shorter?** U8 step 6 says "~3-5 days." The rewrite removed the 2-week parallel run; how short should the new safety window be? 24h? 72h? Worth a one-line user-confirmation step in U6's runbook before destroy.
+5. **The probe captured `tid=32bffe65-3e64-414f-9d21-069572b800eb` for cullenwines.com.au.** Should the helper hardcode this as a fallback if `OAUTH_TENANT=common` ever fails? Probably no — `common` works and avoids tenant-rename brittleness — but worth a sentence in the wiki doc capturing the known good tenant ID for reference.
+
+## Verdict
+
+**Needs one more pass, but a small one.** The rewrite landed all 12 round-1 issues and honored every user directive. The only must-fix is **N-C1** (`maildir-deduplicate` is not packaged — claim is wrong, U7c needs a different tool or inline Python fallback). The should-fix items (**N-S1** through **N-S5**) are all 1-2 sentence patches that don't change architecture: rephrase the deletion-resistance test, add a U-ID continuity note, specify how the helper is exposed for `nix-run`, document the OAUTH_TENANT default rationale, and add a one-line note about PassCmd shell-safety.
+
+Priority order for the third pass:
+1. **N-C1** (must-fix): drop `maildir-deduplicate` claim from Open Questions and U7c approach; replace with inline-Python fallback or document as "inline Python equivalent if dedup is ever wanted; manual review recommended."
+2. **N-S3** (should-fix): specify the helper's packaging surface (flake app or top-level package) so U6's `nix-shell -p` / `nix run` invocation actually resolves.
+3. **N-S1** (should-fix): rephrase U8 step 4's deletion-resistance test to exercise mbsync state, not the rc.
+4. **N-S2, N-S4, N-S5** (nits with action): one-sentence clarifications.
+
+After that, the plan is ready for `/ce-work`.

--- a/docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan-REVIEW.md
+++ b/docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan-REVIEW.md
@@ -1,0 +1,180 @@
+# Plan Review: Mailarchive / Mailstore VM Retirement
+
+**Reviewer:** independent agent
+**Date:** 2026-05-04
+**Plan reviewed:** docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan.md
+
+## Summary
+
+The plan is substantively sound on architecture and infrastructure wiring — it correctly mirrors the kopia.nix shape, honours the monitor noise discipline, and traces back to the requirements/research/probe trio. But three concrete bugs would derail implementation if not caught: (1) the json-query monitor's `expectedValue = "<600"` does not work — `monitoring_sync.nix` hardcodes `jsonPathOperator = "=="`, so the comparator form silently fails open; (2) U6's runbook tells the user to rebuild `#proxmox-vm` from doc2 — that is doc1's flake target, the U8 fixup is correct but never propagated back into U6; and (3) the migration's Maildir++ folder layout (U7b) doesn't match the live mbsync's `SubFolders Verbatim` layout (U3), so the dedupe in U7c will see two parallel folder hierarchies and won't merge them. Plus several smaller issues (mbsync `Create Both` is unsafe for an archive, `vms/definitions.nix` doesn't exist, `/mnt/data` is NFS to tower not virtiofs, Gmail `Patterns *` will multiply messages via labels). Worth one revision pass before shipping.
+
+## Critical Issues (must-fix before implementation)
+
+### C1. `expectedValue = "<600"` will not work; switch to server-side boolean now (not "verify at implementation time")
+
+The plan flags this as a "verify at implementation time" item (U4 approach + Open Questions). Verification is conclusive *now*: it doesn't work. In `modules/nixos/services/monitoring_sync.nix:201` the operator is hardcoded:
+
+```python
+common_kwargs["jsonPathOperator"] = "=="
+```
+
+`expectedValue` is then passed straight to Uptime Kuma as a literal equality compare. So `expectedValue = "<600"` will be compared as `<actual> == "<600"` — always false → monitor permanently DOWN, or always true depending on Kuma's coercion of the literal string. Either way, not the semantics you want.
+
+**Fix:** the plan's "fallback" should be the primary plan. The heartbeat HTTP server should compute `healthy: true|false` server-side and the monitor uses `jsonPath = "$.healthy"`, `expectedValue = "true"`. Alternatively, `homelab.monitoring.monitors` could be extended to expose `jsonPathOperator` — but the plan explicitly defers that, and that's a sound call given scope. Just make the boolean shape canonical from U4 onwards.
+
+### C2. U6 runbook deploys to the WRONG host (doc1, not doc2)
+
+Plan line 399:
+> `nixos-rebuild switch --flake github:abl030/nixosconfig#proxmox-vm --refresh` from doc2 (per CLAUDE.md remote-deploy rule).
+
+Per `hosts.nix`, `proxmox-vm` is doc1 (vmid 104). doc2's flake key is literally `doc2` (`hosts.nix:298-303`). The plan correctly identifies this in U8 step 3 with a parenthetical fixup ("wait, doc2 is `doc2`, not `proxmox-vm` (which is doc1). Use `ssh doc2 "...#doc2 --refresh"`") — but the U6 runbook still has the wrong target embedded. A future user following the bootstrap runbook *first* (which is exactly the recommended order) would rebuild doc1 instead of doc2.
+
+**Fix:** scrub U6 to use `--flake github:abl030/nixosconfig#doc2 --refresh` and `ssh doc2 "..."`. Drop the meta-narrative fixup from U8 step 3 entirely — it shouldn't be in the plan at all, just write the right command.
+
+### C3. Migration (U7b) and live tree (U3) use incompatible Maildir layouts
+
+U3 sets `SubFolders Verbatim`, which produces (per `man mbsync`):
+> `Path/top/sub/subsub` and `Inbox/sub/subsub` (this is the style you probably want to use)
+
+i.e. nested directories: `/mnt/data/Life/Andy/Email/work/Inbox/Sent Items/cur/`.
+
+U7b's migration script writes:
+> Reconstruct folder hierarchy as Maildir subfolders (`Maildir/.Folder.Subfolder/`, with `.` separator per Maildir++ convention).
+
+i.e. flat dot-separated names: `/mnt/data/Life/Andy/Email/work.archive/.Inbox.Sent Items/cur/`.
+
+Same logical folder, different path. The U7c dedup ("merge against live") will see them as siblings, not duplicates of the same folder, and the dedup-by-Message-ID across the *whole* tree will work but the resulting tree will have two parallel hierarchies — half flat-Maildir++, half nested-Verbatim. mbsync also won't merge in any future-fetched messages with the migrated tree because mbsync's state lives per-folder.
+
+Also: per `man mbsync`, "attempts to set `Path` are rejected" with `SubFolders Maildir++`. So even if you wanted to flip the live mbsync rc to `Maildir++`, the rc stanza in U3 (which sets `Path`) won't validate.
+
+**Fix:** pick one layout and use it everywhere. Recommended: `SubFolders Verbatim` in mbsync (matches U3) AND have the migration script reproduce nested directories (drop the `.Folder.Subfolder` flattening). This is simpler — no Maildir++ encoding edge cases to care about. Update U7b's "approach" bullet accordingly.
+
+## Should-Fix Issues (would cause friction or technical debt if unaddressed)
+
+### S1. `vms/definitions.nix` does not exist; VM 102 is not in fleet inventory
+
+The plan tells the implementer to "Update `vms/definitions.nix` to drop VM 102" (U8 step 6) and lists `vms/definitions.nix no longer references VM 102` as a verification gate. Reality:
+
+- `vms/definitions.nix` does not exist on this branch (`find /home/abl030/nixosconfig/vms -name 'definitions.nix'` → empty).
+- VM 102 is not in `hosts.nix`, not in `vms/tofu/vm-resources.nix`, not in any inventory file (grep'd `vmid = 102` and `"102"` across the repo — zero hits).
+- CLAUDE.md *does* still list `vms/definitions.nix` as an "Important Files" entry (line 312); that's a CLAUDE.md staleness bug, separate but related.
+
+VM 102 is a Proxmox-side-only VM (created by hand, lives on `nvmeprom`, never managed by NixOS/OpenTofu). Retirement is purely a Proxmox operation — no fleet-config changes needed.
+
+**Fix:** drop the `vms/definitions.nix` references from U8 step 6 and the verification block. Replace with: "after destroy, run `vms/proxmox-ops.sh list` and confirm 102 is gone; no fleet config changes needed because 102 was never inventoried." Optionally: file a separate issue to update CLAUDE.md's stale "Important Files" line.
+
+### S2. `/mnt/data` is NFS to tower (Unraid), not virtiofs
+
+The plan repeatedly characterises `/mnt/data` as virtiofs (e.g. "the virtiofs mount is already provisioned on doc2", System-Wide Impact bullet about "/mnt/data (virtiofs from prom)"). It is not. `modules/nixos/services/mounts/nfs-local.nix:27-43` mounts `/mnt/data` from `192.168.1.2:/mnt/user/data/` as NFSv4.2. `/mnt/virtio` is the virtiofs mount (separate, e.g. used by all the other doc2 services for state).
+
+This matters operationally:
+- If tower (192.168.1.2) goes down, `/mnt/data` goes stale, `mailarchive-*.service` will fail to write, `nfsWatchdog.mailarchive-*` will catch it (good — that wiring is correct). The watchdog is genuinely needed because the mount is genuinely network-shared.
+- The data lives on tower's array, not on prom. Kopia from doc2 reads it via NFS. That's the existing topology.
+- The systemd unit name `mnt-data.mount` works regardless (systemd names by mountpoint, not FS type) — so the `requires = ["mnt-data.mount"]` line in U3 is correct.
+
+**Fix:** correct the prose throughout the plan ("virtiofs" → "NFS to tower / Unraid"). It's misleading framing that future readers will inherit. The actual systemd wiring is fine.
+
+### S3. mbsync `Create Both` and bidirectional `Sync All` are unsafe for an archive
+
+U3 lists the rc structure as: `Sync All`, `Create Both`, `Expunge None`, `SyncState *`.
+
+- `Create Both` will create new local folders on the *remote* IMAP server if they appear locally. After U7b runs, `o365.archive/.Inbox.Sent Items` (or whatever) exists on the local Maildir; the next mbsync run will *create that folder upstream on cullenwines.com.au's Exchange*. Side-effect on the live mailbox.
+- `Sync All` propagates everything in both directions, including the migration script's `:2,S` Seen flag — which mbsync will *push back to O365*, marking historical messages as read on the live server.
+
+Neither is what an archive wants. A proper archive is one-way pull: messages flow remote → local, never the other direction.
+
+**Fix:** the rc should be `Sync Pull` (or explicitly `Sync Pull Flags Gone` if you want to track flag changes from the server) plus `Create Near`, `Remove None`, `Expunge None`. Update U3's "Approach" accordingly. The plan does say final flags get tuned during U2/U3 — but the listed defaults are dangerous, not just imperfect.
+
+### S4. Gmail `Patterns *` will multiply messages via labels
+
+Gmail's IMAP exposes labels as folders, and every labelled message appears in *every* folder (label) it has, plus `[Gmail]/All Mail`. With `Patterns *`, mbsync will fetch the same message N+1 times into N+1 different Maildir folders.
+
+For a backup-of-record use case, fetching only `[Gmail]/All Mail` once is the canonical answer (every message lives there exactly once). For per-folder organisation, you fetch labels separately but **exclude** All Mail to avoid duplication. The plan doesn't address this and will result in massive over-fetch, duplication, and Kopia bloat.
+
+**Fix:** Gmail rc should use `Patterns "[Gmail]/All Mail"` (or similar) and exclude other folders. Document the choice in U3 and the runbook. Make this an explicit per-provider policy in the module.
+
+### S5. Push-monitor / heartbeat scheme couples mailarchive to kuma's host
+
+The monitor URL `http://localhost:9876/health/<account>` works because kuma and mailarchive are both on doc2. If kuma ever moves (it has moved between doc1/doc2 historically, see `docs/wiki/services/lgtm-stack.md` style migrations), the monitor will silently break — kuma will probe `localhost:9876` from its new host and find nothing.
+
+Same problem in reverse: the plan claims (Open Questions resolved) that pull/json-query "matches existing patterns and keeps `homelab.monitoring` unchanged." But kopia's existing json-query monitors at `http://localhost:51515/api/v1/sources` (kopia.nix:348) *also* assume kuma is on doc2 — so this is a fleet-wide hidden constraint. Worth surfacing in the plan rather than ignoring.
+
+**Fix:** add a short note in the plan under "System-Wide Impact" or "Risks" that the localhost monitoring URL pattern assumes kuma is co-located with the service. Either accept the constraint explicitly or use `https://<service>.ablz.au` via localProxy and depend on the LAN-only proxy. Probably accept-and-document; localProxy for a localhost health endpoint is overkill.
+
+### S6. `secrets/.sops.yaml` change in U1 is unnecessary
+
+U1 says: "Modify: `secrets/.sops.yaml` (add `mailarchive-*.env` to the encrypted-files glob if needed)."
+
+`.sops.yaml` uses `path_regex: .*` — already matches everything. No edit needed. The "if needed" is doing some work but a junior implementer following the plan literally will go look for a glob and waste time. Just delete that bullet.
+
+### S7. `Inbox` directive with `SubFolders Verbatim` may trip mbsync
+
+The plan's mbsync rc snippet:
+```
+MaildirStore <name>-local:
+  Path /mnt/data/Life/Andy/Email/<name>/
+  Inbox /mnt/data/Life/Andy/Email/<name>/INBOX/
+  SubFolders Verbatim
+```
+
+With `Path` set, mbsync expects subfolder paths to be relative under `Path`. Setting `Inbox` to a path *under* `Path` is supported but redundant; `SubFolders Verbatim` then yields `Path/INBOX/` for the INBOX. The plan's verification step ("messages appear under `/mnt/data/Life/Andy/Email/work/INBOX/cur/`") is consistent with this layout.
+
+**Fix:** likely just drop the explicit `Inbox` line; let mbsync put INBOX under `Path` per Verbatim's default. Worth verifying empirically during implementation.
+
+### S8. `path = with pkgs; [ isync cyrus-sasl-xoauth2 ]` may not be enough for SASL plugin discovery
+
+U3's "Approach" claims "the systemd `path` setting handles `LD_LIBRARY_PATH`-equivalent for the unit." This is wrong: systemd's `Environment.PATH` (`path = [...]` in NixOS lingo) sets `$PATH`, not `$LD_LIBRARY_PATH` and not the SASL plugin search path. cyrus-sasl-xoauth2 is a `libsasl2` plugin loaded at runtime by libsasl, which scans `/usr/lib/sasl2/` or paths via `SASL_PATH`.
+
+The kopia precedent doesn't help here (kopia doesn't use SASL plugins). On NixOS, the standard pattern is to point `SASL_PATH` at `${pkgs.cyrus-sasl-xoauth2}/lib/sasl2`. Without that, mbsync will say "SASL XOAUTH2 not available" at runtime even though the plugin is in the closure.
+
+The plan's risk row mentions this in passing ("verify in U3 with `mbsync -V` listing XOAUTH2") but the proposed mitigation (`path = ...`) won't actually fix it.
+
+**Fix:** in U3, set `serviceConfig.Environment = "SASL_PATH=${pkgs.cyrus-sasl-xoauth2}/lib/sasl2"` (or similar). Reference: nixpkgs has done this for other XOAUTH2-using services; check `pkgs.isync`'s test suite or the [cyrus-sasl-xoauth2 README](https://github.com/moriyoshi/cyrus-sasl-xoauth2). The plan-attached probe v2 script bypassed mbsync entirely (raw IMAP), so didn't exercise this.
+
+### S9. U7c sequencing is fine but worth restating
+
+The instructions ask to verify U7c fires *after* U8's 14-day green window. Plan U8 step 5 says: "U7c dedupe (run `maildir-deduplicate` against `o365.archive/` + live `o365/` if the user wants the historical archive merged into the live tree; or keep them separate forever, which is also fine and arguably safer)."
+
+U7's "Dependencies" line says: "(independent of U1-U5; can be done before or after the live module is deployed, but the dedupe step in U7c happens after U8's parallel-run)." Consistent with U8 step 5. Good.
+
+But the structural mismatch in C3 means U7c's dedup will not actually merge folders — it would only deduplicate Message-IDs across two parallel Maildir trees. Once C3 is fixed, U7c's dedup becomes meaningful.
+
+## Nits
+
+- **Monitoring noise math is correct.** 60s × 10 retries = 600s = 10min before page; 240 heartbeats × 60s = 4h re-page. The plan's `expectedValue = "<600"` even encodes the same 10-minute threshold (matching maxretries × interval). When you fix C1 to use boolean, keep the *server-side* threshold at 600s so the page-after-10-minutes semantics is preserved.
+- **Bootstrap eventual-consistency callout is adequate but could be stronger.** U6's wording ("the very first `mailarchive-work.service` run may show `AUTHENTICATE failed` in journalctl — wait 5 minutes and let the timer fire again") is fine for a calm reader. For an anxious reader at midnight, consider adding "this is *expected* and not a failure of the bootstrap; do not re-run the bootstrap, just wait 5 minutes." Minor.
+- **`runAsRoot` is appropriately omitted.** kopia.nix has `runAsRoot` because kopia accesses NFS paths with restrictive perms; mailarchive writes its own Maildir owned by the `mailarchive` user, so `runAsRoot` would be inappropriate. Plan correctly skips it. Good — well calibrated.
+- **R-ID traceability is decent but spotty.** R1-R9 map cleanly to U1-U9 with cross-refs. But R6's wording "fetcher hasn't successfully synced within ~10 minutes" is the *threshold*, not the *retry-count math*. A future reader may confuse "10 minutes" (R6) with "10 retries" (rule). Fine as written but worth a one-line clarification: "10 minutes of staleness comes from server-side threshold + the fact that maxretries × interval also ≈ 10 min."
+- **`docs/runbooks/` is a new directory.** No existing runbooks per `find docs/runbooks -type f` (didn't run, but the plan says "if any exist; otherwise model on the docs/wiki/services/ doc style"). Worth choosing one location consistently — recommend `docs/wiki/services/mailarchive.md` instead, since the wiki convention already covers "research findings, architectural decisions, … operational knowledge" per CLAUDE.md. A separate `docs/runbooks/` tree fragments where institutional knowledge lives.
+- **Test scenarios for U6/U9 ("none — documentation artifact") are correctly justified** (those units produce only docs). U1-U5, U7 all have specific scenarios. Good calibration.
+- **U2 "no automated tests" is correct** — the probe v2 already validated the chain end-to-end. Good calibration.
+- **Helper script: `pkgs.writers.writePython3Bin "oauth2-helper" {libraries = [];}` works** — confirmed pattern via `podcast.nix:14-20`. Stdlib-only is correct: the probe v2 script (~120 lines) was stdlib-only.
+- **`maildir-deduplicate` packaging.** Easy check: it's available as `pkgs.python3Packages.maildir-deduplicate` in nixpkgs unstable. Not worth deferring; just bake it into U7c.
+- **`Mailstore-export/` staging cleanup in U8 step 6.** Fine, one line. Mention which path explicitly so a future reader doesn't grep blind: it's whatever U7a wrote ("`\\doc2\share\mailstore-export\` or any path reachable from doc2") — pick one canonical path in U7a and reference it in U8.
+
+## Strengths Worth Preserving
+
+- **Origin coverage is solid.** Every Requirement (R1-R9), Open Question, and Risk in the requirements/research/probe trio is addressed by an Implementation Unit. The probe pivot to Architecture 1 is internalised; DavMail rejection is reasoned from the probe, not just asserted. Good chain of custody.
+- **kopia.nix mirroring is the right call and is mostly correctly done.** Submodule shape, sops dotenv per-instance, NFS watchdog, monitoring with `homelab.monitoring.monitors`, mount dependency wiring (`mountDepsFor` analogue), per-instance systemd timers via `lib.mapAttrs'` — all correct and scoped right. The plan correctly omits `runAsRoot` (mailarchive is single-user, owns its own data) and doesn't blindly copy the kopia verify-script pattern (which would be inappropriate). Good restraint.
+- **restartTriggers omitted.** Correct: mailarchive doesn't have a DB container, so the `restartTriggers` rule doesn't apply. Plan correctly skips.
+- **Monitoring noise discipline honoured.** `interval = 60`, `maxretries = 10`, `retryInterval = 60`, `resendInterval = 240` matches the rule exactly. The math checks out.
+- **DNS-first networking respected.** No hardcoded LAN IPs in module options or runtime config (the localhost monitor URL is the right exception per the rule, since it's the same-host loopback case, not a fleet IP).
+- **Sops layout correct.** `secrets/hosts/doc2/mailarchive-<account>.env` is the canonical `homelab.secrets.sopsFile` host path (verified `modules/nixos/common/secrets.nix:35`). The plan got this right.
+- **Service hierarchy correct.** mbsync and cyrus-sasl-xoauth2 are nixpkgs packages with no upstream module → custom systemd unit (Tier 2 per `.claude/rules/nixos-service-modules.md`). Plan correctly avoids OCI containers (Tier 3). DavMail's rejection is well-reasoned from the probe.
+- **Deployment pattern documented.** U8 step 3 calls out the `--target-host` prohibition correctly and uses the `git push + ssh + nixos-rebuild --refresh` pattern from CLAUDE.md.
+- **Parallel-run safety net.** 14 days of green monitors before VM 102 destruction, then another week with VM 102 stopped before destroy — that's an appropriately paranoid cadence for a backup-of-record.
+- **`Expunge None` semantics articulated.** The plan correctly identifies this as the deletion-resistance lever and tests for it in U3 ("Integration: deleting a message from O365 via OWA after it's been archived leaves the Maildir copy intact").
+
+## Open Questions for the Author
+
+1. **What happens to the existing Thunderbird IMAP fetch on the Win VM during the 14-day parallel run?** If both the Win VM Thunderbird *and* the new mailarchive on doc2 have IMAP IDLE / polling sessions open against O365 with the same account, will Microsoft's per-account session limits cause one to fail? Worth probing once before parallel-run begins. Likely fine (multiple concurrent IMAP sessions are normal) but unproven.
+
+2. **Does the user actually want O365 sent items archived?** Implicit in the plan is that "archive everything." Sent items are typically the most valuable historical record (the user's outbound prose), but the plan doesn't enumerate folder selection. Worth confirming with a 1-line checklist in U6's runbook: "INBOX, Sent Items, Archive, [other folders]?" Otherwise the user may not notice missing folders for months.
+
+3. **Is the 11 GB MailStore archive Gmail-only, O365-only, or mixed?** The plan assumes "11 GB MailStore archive" can be partitioned to `o365.archive/` and `gmail.archive/`. MailStore Home stores everything in one repository by archive profile; if the user has multiple profiles, partitioning is straightforward — if it's one mixed profile, the EML export tree's per-folder hierarchy needs to be inspected before deciding the target tree. U7a should explicitly capture how the archive was structured.
+
+4. **Will Kopia notice the new ~11 GB tree all at once?** When U7b lands the migrated archive into `/mnt/data/Life/Andy/Email/o365.archive/`, the next Kopia snapshot will see ~11 GB of new files. The plan flags this as "acceptable" in Risks but doesn't reason about Kopia's chunk-dedup behaviour. EMLs are very dedup-friendly (RFC822 has lots of common header structure) but the bandwidth/wall-time hit on the *first* snapshot run could be noticeable. Worth a sentence on whether to throttle or run off-hours.
+
+5. **Does this plan introduce a new dependency on cyrus-sasl-xoauth2 0.2 in nixpkgs being stable?** The research doc dates the package version. If the package has a known regression in current `nixpkgs unstable` (the project's pin), the plan won't surface it. A pre-build sanity check via mcp-nixos `nix info isync` and `nix info cyrus-sasl-xoauth2` in U3 implementation would catch this.
+
+6. **The plan's cleanup of `/tmp/davmail-probe/` and `/tmp/mailprobe/` is described in the probe doc but not echoed in this plan.** If those probe artifacts haven't been cleaned up by the time U8 step 5 runs, they may interfere with new probe runs during token rotation. Probably fine but worth a one-line "verify probe artifacts are gone" in the runbook.

--- a/docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan.md
+++ b/docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan.md
@@ -1,0 +1,614 @@
+---
+title: "feat: NixOS mailarchive module + MailStore VM retirement"
+type: feat
+status: active
+date: 2026-05-04
+origin: docs/brainstorms/2026-05-04-mailstore-vm-replacement-requirements.md
+---
+
+# feat: NixOS mailarchive module + MailStore VM retirement
+
+## Summary
+
+Build a NixOS service module (`homelab.services.mailarchive`) on doc2 that uses `mbsync` + `cyrus-sasl-xoauth2` plus a small Python OAuth refresh helper to continuously archive personal Gmail and work O365 (cullenwines.com.au) into Maildir under `/mnt/data/Life/Andy/Email/<account>/`. Migrate the 11 GB existing MailStore Home archive (mixed Gmail + O365, single repository) into a one-shot `legacy.archive/` Maildir tree. Smoke-test the live fetch with a few real messages, then stop and destroy VM 102 with a short safety window. Operational shape is one fetcher per account driven by a systemd timer, sops-encrypted refresh tokens, a heartbeat sentinel polled by Uptime Kuma, and the existing `homelab.nfsWatchdog` covering the NFS mount to tower.
+
+---
+
+## Problem Frame
+
+The Windows 10 VM (VMID 102 on prom) exists solely to run Thunderbird + MailStore Home for email archiving. Win10 is out of support, the VM is the last Windows box in the fleet, and the historical MailStore proprietary `.dat`/`.rr` format prevents any non-MailStore tooling from reading the archive. The brainstorm + research + probe trio (see Sources & References) settled architecture, verified OAuth and IMAP end-to-end against the live cullenwines.com.au tenant, and confirmed Thunderbird is already tenant-consented — making `mbsync` direct with Thunderbird's published client_id viable without IT involvement.
+
+This plan is the HOW: NixOS module shape, OAuth helper, monitoring wiring, migration script, cutover sequence, and operational runbook for refresh-token rotation. (See origin: `docs/brainstorms/2026-05-04-mailstore-vm-replacement-requirements.md`.)
+
+---
+
+## Requirements
+
+- R1. Continuous IMAP archival of personal Gmail and work O365 to Maildir, with deletion-resistance (capture before user deletes from work mailbox).
+- R2. OAuth2 authentication with no app registration in the work Entra tenant; uses Thunderbird's existing tenant consent.
+- R3. Storage as Maildir (one file per message) under `/mnt/data/Life/Andy/Email/<account>/`, included by existing Kopia snapshots (Wasabi + offsite).
+- R4. One-shot migration of the existing 11 GB MailStore Home archive (mixed Gmail + O365) into a single `legacy.archive/` Maildir tree; MailStore retired entirely (no proprietary-format hangover).
+- R5. NixOS module under `modules/nixos/services/mailarchive.nix` following `.claude/rules/nixos-service-modules.md` (options under `homelab.services.mailarchive`, sops, monitoring, NFS watchdog).
+- R6. Uptime Kuma monitor that goes red when a fetcher hasn't successfully synced within ~10 minutes (per the project's noise-discipline defaults).
+- R7. Refresh-token bootstrap is a documented one-time interactive procedure; subsequent operation is fully unattended for ≥90 days.
+- R8. Cutover plan that smoke-tests the live fetch against real messages (test send + observed mbsync run + Kuma green for both accounts), stops VM 102, waits a short safety window with disks intact, then destroys the VM.
+- R9. Operational runbook for recovering from Microsoft revoking Thunderbird's client_id (precedent: 2024-08-01 retirement of `08162f7c-…`).
+
+---
+
+## Scope Boundaries
+
+- No web UI archive product (Mailpiler, Stalwart, Roundcube, etc.) — overkill for ~3x/year retrieval; user wants format openness, not a UI.
+- No replacement of daily mail clients — Outlook on work laptop and Gmail web stay.
+- No search or indexing infrastructure (notmuch, mu, mairix). Deferred; Maildir keeps the door open.
+- No Entra app registration in the work tenant; no IT involvement.
+- No DavMail (rejected after probe — DavMail's client_id requires admin consent we can't grant).
+- No headless Thunderbird (rejected — same OAuth surface as mbsync, more moving parts).
+
+### Deferred to Follow-Up Work
+
+- **Search/indexing**: a future plan can add notmuch or mu against the same Maildir tree without changes to this module.
+- **`homelab.monitoring` json-query operator support**: today the sync hardcodes `==`. This plan works around that with a server-side boolean health check; a separate refactor could expose `jsonPathOperator` in the module.
+- **Splitting the legacy archive per-account**: the MailStore archive is mixed; it lands as one `legacy.archive/` tree. If we ever want it split by account, that's a separate one-shot script.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `modules/nixos/services/kopia.nix` — closest pattern match: `homelab.services.kopia.instances = attrsOf submodule`, sops dotenv, NFS-aware service wiring, `homelab.nfsWatchdog`/`homelab.monitoring` registration, json-query monitor with `basicAuthUserEnv`/`basicAuthPassEnv`. Mirror its shape closely. Note: kopia uses `runAsRoot` for restrictive NFS perms; mailarchive does not need this — it owns its own Maildir as the `mailarchive` user.
+- `modules/nixos/services/nfs-watchdog.nix` — confirms the watchdog API: one-line registration `homelab.nfsWatchdog.<name>.path = "..."`. Default 5min interval. The watchdog restarts `<name>.service`, so naming the watchdog entry `mailarchive-<name>` is correct.
+- `modules/nixos/services/monitoring_sync.nix:201` — read-only context: confirms `jsonPathOperator` is hardcoded to `==`, so json-query monitors must use server-side boolean health checks rather than client-side comparators. The plan honours this in U4.
+- `modules/nixos/services/mounts/nfs-local.nix` — mounts `/mnt/data` from `192.168.1.2:/mnt/user/data/` (tower / Unraid) as NFSv4.2. The systemd unit is `mnt-data.mount`. `/mnt/virtio` is separate and is the virtiofs mount used for VM-local state.
+- `modules/nixos/services/podcast.nix` — pattern for `pkgs.writers.writePython3Bin` with `libraries = [...]`. Use for the OAuth refresh helper.
+- `modules/nixos/services/default.nix` — register the new module by adding `./mailarchive.nix` to the imports list.
+- `hosts/doc2/configuration.nix` — confirms `/mnt/data` is mounted on doc2 (already used by `kopia` for the photos backup).
+- `modules/nixos/common/secrets.nix:35` — confirms `secrets/hosts/<hostname>/` is the canonical search path for `homelab.secrets.sopsFile`.
+- `.claude/rules/nixos-service-modules.md` — service hierarchy, monitoring noise discipline (interval=60, maxretries=10, retryInterval=60, resendInterval=240).
+
+### Institutional Learnings
+
+- The probe (`docs/brainstorms/2026-05-04-mailstore-vm-probe-result.md`) demonstrated a Microsoft eventual-consistency quirk on first-auth: an access token can pass OAuth validation seconds after consent yet still be rejected by Exchange Online's IMAP service for a few minutes until consent propagates. **Implication for the bootstrap runbook**: after bootstrap, the very first sync attempt may show `AUTHENTICATE failed` in journal — this is **expected**, not a bootstrap failure. Wait 5 minutes; do not re-bootstrap.
+- The probe confirmed Thunderbird's published OAuth client_id `9e5f94bc-e8a4-4e73-b8be-63364c29d753` is registered as an Activated Enterprise App on cullenwines.com.au with object ID `ffa49eb9-9ee2-4ac1-9207-e05cf008015a`. No admin consent needed.
+- Multiple concurrent IMAP sessions against the same O365 mailbox are normal Exchange Online behaviour. The Win VM Thunderbird and the new mailarchive can both connect during the cutover window without provoking session limits.
+
+### External References
+
+- The companion research doc (`docs/brainstorms/2026-05-04-mailstore-vm-replacement-research.md`) covers the per-tool comparison (mbsync vs getmail6 vs OfflineIMAP) and the MailStore migration mechanics.
+- Microsoft auth scope: `offline_access https://outlook.office.com/IMAP.AccessAsUser.All`, OAuth endpoint `https://login.microsoftonline.com/common/oauth2/v2.0/`.
+- Gmail OAuth scope: `https://mail.google.com/`, OAuth endpoint `https://oauth2.googleapis.com/`.
+- `cyrus-sasl-xoauth2` plugin lookup: at runtime via `SASL_PATH=${pkgs.cyrus-sasl-xoauth2}/lib/sasl2`. The systemd `path` setting only sets `$PATH`; SASL plugins need the `SASL_PATH` env var. See [moriyoshi/cyrus-sasl-xoauth2 README](https://github.com/moriyoshi/cyrus-sasl-xoauth2).
+
+---
+
+## Key Technical Decisions
+
+- **One module, two providers (`gmail` and `o365`).** Per-account submodule with a `provider` enum drives the small differences in OAuth flow (Gmail needs `client_secret`; Microsoft public client doesn't) and the folder-set defaults. Same fetcher, same Maildir layout, same monitoring wiring.
+- **OAuth refresh helper as a single `pkgs.writers.writePython3Bin` script** (~80 lines, stdlib only). Invoked by mbsync's `PassCmd` once per sync; exchanges the on-disk refresh token for a fresh access token; prints it. Same tool, two subcommands: `refresh` (used by mbsync) and `bootstrap` (one-time interactive). Matches the probe v2 script structure that already validated end-to-end.
+- **Refresh tokens stored in sops dotenv per account** at `secrets/hosts/doc2/mailarchive-<account>.env`. Format: `OAUTH_REFRESH_TOKEN=...`, plus `OAUTH_CLIENT_ID`, `OAUTH_TENANT` (O365 only), `OAUTH_CLIENT_SECRET` (Gmail only).
+- **mbsync as a oneshot systemd unit fired by a per-account timer**, not as a daemon. Polling intervals: 60s for O365 (delete-resistance), 120s for Gmail (Gmail retains everything; less critical). Matches `kopia-verify-*` timer pattern.
+- **mbsync direction is one-way Pull only.** rc uses `Sync Pull`, `Create Near`, `Remove None`, `Expunge None`. Rationale: this is a backup-of-record, not a synced mailbox. Two-way `Sync All` would push local Maildir state (including the migration script's `:2,S` Seen flags) back to the live server, marking historical messages read. `Create Both` would create local-only folders upstream on the live mailbox. Both are unsafe for an archive. `Expunge None` is the deletion-resistance lever — when the user deletes from O365 the Maildir copy stays.
+- **Folder selection is provider-specific:**
+  - **O365**: explicit folder set — `Patterns "INBOX*" "Sent Items*" "Archive" "Archives*" "Drafts" "Deleted Items*" "Junk Email"`. Captures everything the user actively organises (probe showed 332 folders, deeply nested under INBOX); excludes `Calendar`, `Contacts`, `Tasks`, `Notes`, `Sync Issues`, `Conversation History`, `Outbox`, `RSS Feeds`, `Templates` which are calendar/state folders not mail. Final pattern list verified at U3 implementation against the live folder tree.
+  - **Gmail**: `Patterns "[Gmail]/All Mail"` only. Gmail's IMAP exposes labels as folders and every message appears in every folder it's labelled with — fetching by label would multiply messages by N. `[Gmail]/All Mail` contains every message exactly once; that's the canonical backup target.
+- **SASL plugin discovery** via `Environment = "SASL_PATH=${pkgs.cyrus-sasl-xoauth2}/lib/sasl2"` on the systemd unit. `path = [...]` only sets `$PATH`; libsasl2 finds plugins via `SASL_PATH` (or `/usr/lib/sasl2`). Verify at first run with `mbsync -V` listing XOAUTH2 in supported AuthMechs.
+- **Maildir layout: `SubFolders Verbatim` everywhere.** mbsync's Verbatim mode produces nested directories (`work/Inbox/Sent Items/cur/`). The migration script (U7) **must** produce the same nested layout so the live and migrated trees are structurally compatible. Maildir++ (flat dot-separated names) is rejected — it doesn't validate alongside an explicit `Path` directive in mbsync rc, and would create two parallel hierarchies if mixed with Verbatim.
+- **Heartbeat via pull/json-query with server-side boolean.** mbsync's `ExecStartPost` touches `/var/lib/mailarchive/<account>.heartbeat` only on success. A long-running Python HTTP server reads heartbeat mtimes and serves `GET /health/<account>` returning `{"healthy": true|false, "stale_seconds": <int>}` based on a server-side threshold (default 600s). Uptime Kuma's json-query checks `$.healthy == "true"`. Rationale: `monitoring_sync.nix` hardcodes the json-query operator to `==`; comparator forms like `<600` would silently fail. Server-side boolean works with the existing module unchanged.
+- **Static system user `mailarchive`** with `extraGroups = ["users"]` for NFS write access to `/mnt/data`. Mirrors the `kopia` user pattern.
+- **`/mnt/data` mount dependency**: `requires = ["mnt-data.mount"]; after = ["mnt-data.mount" "network-online.target"];`. `/mnt/data` is NFSv4.2 to tower (192.168.1.2 / Unraid), not virtiofs — the systemd unit name is `mnt-data.mount` regardless of FS type, so the wiring is the same; the watchdog is genuinely needed because the mount is genuinely network-shared.
+- **Module location: `modules/nixos/services/mailarchive.nix` (single file)** rather than a directory.
+- **Migration: single `legacy.archive/` tree (mixed Gmail + O365).** The MailStore archive is mixed and not partitioned per-account. The migration imports everything to one tree under `/mnt/data/Life/Andy/Email/legacy.archive/` preserving MailStore's folder hierarchy. The live trees `o365/` and `gmail/` are siblings. Deduplication between legacy and live is optional and deferred — see U7.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **DavMail vs mbsync direct**: resolved by probe; mbsync direct via Thunderbird client_id works.
+- **Where does the heartbeat sentinel live?**: `/var/lib/mailarchive/<account>.heartbeat`. Owned by the `mailarchive` user.
+- **Push or pull monitoring?**: pull via json-query with **server-side boolean** (not client-side comparator — the existing `monitoring_sync.nix` hardcodes `==`).
+- **OAuth scope set**: `offline_access https://outlook.office.com/IMAP.AccessAsUser.All` for O365; `https://mail.google.com/` for Gmail.
+- **Migration target structure**: single `legacy.archive/` tree (the MailStore archive is mixed Gmail + O365 in one repository). Maildir layout `SubFolders Verbatim` matching the live trees.
+- **Sync intervals**: 60s O365, 120s Gmail.
+- **Folder selection**: O365 fetches mail folders explicitly (INBOX, Sent Items, Archive(s), Drafts, Deleted Items, Junk); excludes calendar/state. Gmail fetches `[Gmail]/All Mail` only.
+- **Concurrent IMAP sessions during cutover**: accepted — multiple IMAP sessions per mailbox are normal.
+- **Dedup tool for U7c**: `maildir-deduplicate` (and the renamed PyPI tool `mail-deduplicate`) are **not** packaged in nixpkgs (verified via mcp-nixos). U7c uses a small inline Python script (~30 lines, stdlib only — Message-ID set walk) instead. The optional dedup is low-risk and the default recommendation is to leave legacy and live trees separate forever.
+- **Runbook location**: `docs/wiki/services/mailarchive.md` (matches the project's existing wiki convention; no new `docs/runbooks/` tree).
+
+### Deferred to Implementation
+
+- **Final mbsync rc detail tuning** — the rc structure is locked but exact pattern strings (e.g., precise list of O365 folder patterns) verify against the live folder tree at first run.
+- **Heartbeat HTTP server port choice** — `9876` is a placeholder; pick an unused port on doc2 at implementation time.
+- **Final shape of the bootstrap script's prompt text** — runbook in U6 specifies what the script does; the literal text gets refined once we run it for real.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```text
+┌────────────────────────────────────────────────────────────────┐
+│  systemd timer (per account, OnUnitActiveSec=60s/120s)         │
+│              │                                                  │
+│              ▼                                                  │
+│  systemd oneshot service: mailarchive-<account>                 │
+│   Environment SASL_PATH=${cyrus-sasl-xoauth2}/lib/sasl2         │
+│              │                                                  │
+│              ▼                                                  │
+│  mbsync -c /etc/mailarchive/mbsync-<account>.rc -a              │
+│              │                                                  │
+│              │  PassCmd → invokes oauth2-helper                 │
+│              │              │                                   │
+│              │              ▼                                   │
+│              │   reads $OAUTH_REFRESH_TOKEN from sops env       │
+│              │   POSTs to provider's token endpoint             │
+│              │   prints fresh access_token                      │
+│              │                                                  │
+│              ▼                                                  │
+│  XOAUTH2 IMAP (Sync Pull, Create Near, Expunge None)            │
+│   → outlook.office365.com OR imap.gmail.com                     │
+│              │                                                  │
+│              ▼                                                  │
+│  Maildir at /mnt/data/Life/Andy/Email/<account>/                │
+│  (SubFolders Verbatim — nested dirs)                            │
+│              │                                                  │
+│              │  ExecStartPost (only on Exec success)            │
+│              ▼                                                  │
+│  touch /var/lib/mailarchive/<account>.heartbeat                 │
+│                                                                 │
+│  ──── Independent watcher ────────────────────────────────────  │
+│                                                                 │
+│  systemd service: mailarchive-health (long-running)             │
+│              │                                                  │
+│              ▼                                                  │
+│  Python http.server on 127.0.0.1:9876                           │
+│  GET /health/<account> →                                        │
+│      {"healthy": true|false, "stale_seconds": <int>}            │
+│              │  (healthy = stale_seconds < THRESHOLD, srv-side) │
+│              ▼                                                  │
+│  Uptime Kuma json-query: $.healthy == "true" → green            │
+└────────────────────────────────────────────────────────────────┘
+```
+
+```text
+Bootstrap (one-time, per account):
+  user runs:  oauth2-helper bootstrap --provider=o365 --user=andy@cullenwines.com.au
+                                    OR --provider=gmail --user=user@gmail.com
+                                       --client-id=<...> --client-secret=<...>
+  helper:     1. presents device-code URL + code
+              2. polls Microsoft / Google token endpoint
+              3. on success, prints sops env block to stdout
+  user:       sops -e -i secrets/hosts/doc2/mailarchive-<account>.env
+              (paste in the printed block)
+              git commit && git push
+              ssh doc2 "sudo nixos-rebuild switch \\
+                --flake github:abl030/nixosconfig#doc2 --refresh"
+```
+
+---
+
+## Implementation Units
+
+- U1. **Create the `homelab.services.mailarchive` module skeleton**
+
+  **Goal:** Land the module file with options, the `mailarchive` system user, sops secret declarations, and the per-account `attrsOf submodule` shape. No fetcher logic yet — this is the chassis everything else hangs off.
+
+  **Requirements:** R5
+
+  **Dependencies:** None.
+
+  **Files:**
+  - Create: `modules/nixos/services/mailarchive.nix`
+  - Modify: `modules/nixos/services/default.nix` (add `./mailarchive.nix` to the imports list)
+
+  **Approach:**
+  - Declare `homelab.services.mailarchive.{enable, dataDir, healthPort, accounts}`. Defaults: `dataDir = "/mnt/data/Life/Andy/Email"`, `healthPort = 9876`. `accounts = attrsOf submodule` with submodule fields `{provider, remoteUser, syncIntervalSec, credentialSecret, folderPatterns}`.
+  - `provider = enum ["gmail" "o365"]`. `syncIntervalSec` derives in module body from provider (60 for o365, 120 for gmail) but the option lets per-account override. `credentialSecret` is a sops secret name (e.g. `"mailarchive/work"`). `folderPatterns = listOf str` defaults to `["[Gmail]/All Mail"]` for gmail and `["INBOX*" "Sent Items*" "Archive" "Archives*" "Drafts" "Deleted Items*" "Junk Email"]` for o365.
+  - Static user `mailarchive`, group `mailarchive`, home `/var/lib/mailarchive`, `extraGroups = ["users"]` (NFS write access). Mirror `kopia.nix:186-192`.
+  - Create `tmpfiles.rules` for `/var/lib/mailarchive` and per-account `${dataDir}/${name}` directories owned by `mailarchive:mailarchive`, mode 0700.
+  - Per-account sops secret declarations: `sops.secrets."mailarchive/<name>" = {sopsFile = config.homelab.secrets.sopsFile "mailarchive-<name>.env"; format = "dotenv"; owner = "mailarchive"; mode = "0400";}`.
+
+  **Patterns to follow:**
+  - `modules/nixos/services/kopia.nix:105-164` — submodule shape and option types.
+  - `modules/nixos/services/kopia.nix:186-200` — static user + sops dotenv pattern.
+  - `.claude/rules/nixos-service-modules.md` — module structure section.
+
+  **Test scenarios:**
+  - Happy path: `nix build .#nixosConfigurations.doc2.config.system.build.toplevel` succeeds with the module imported and `enable = false`.
+  - Edge case: with `enable = true` and one account configured, `nixos-rebuild build --flake .#doc2` succeeds; check that the `mailarchive` user is created and per-account tmpfiles rules are present in the activation script.
+  - Edge case: with `enable = true` but `accounts = {}`, the build still succeeds and creates no per-account state.
+  - Test expectation: no automated test suite — validation is via `nix flake check` and `nixos-rebuild build`.
+
+  **Verification:**
+  - `nix flake check` passes.
+  - `nix build .#nixosConfigurations.doc2.config.system.build.toplevel` succeeds.
+  - Module appears in the imports list and `homelab.services.mailarchive` shows up in `eval` output.
+
+---
+
+- U2. **OAuth refresh helper script (`pkgs.writers.writePython3Bin`)**
+
+  **Goal:** A single Python binary, callable two ways: as `oauth2-helper refresh --provider=<gmail|o365>` (used by mbsync's `PassCmd` — prints a fresh access token to stdout, exits 0) and as `oauth2-helper bootstrap --provider=<...> --user=<...>` (one-time interactive — runs device-code flow, prints sops env block to stdout for the user to paste into their secret file).
+
+  **Requirements:** R2, R7, R9
+
+  **Dependencies:** U1.
+
+  **Files:**
+  - Modify: `modules/nixos/services/mailarchive.nix` (add the helper definition near the top of the module's `let ... in` block; expose it as a top-level package via `pkgs.callPackage` indirection or a tiny helper module so the module body and `flake.nix` share one definition)
+  - Modify: `flake.nix` — expose the helper as `packages.${system}.oauth2-helper` and `apps.${system}.oauth2-helper` so it's invokable via `nix run github:abl030/nixosconfig#oauth2-helper -- bootstrap ...` from any clone. Mirrors the existing `apps.${system}.fmt-nix` / `lint-nix` pattern (per CLAUDE.md "Common Commands"). This is the bootstrap chicken-and-egg fix: the user must be able to run the helper *before* the module is enabled on doc2 to capture the initial refresh token.
+
+  **Approach:**
+  - Use `pkgs.writers.writePython3Bin "oauth2-helper" {libraries = [];} ''<python>''`. Stdlib only — `urllib.request`, `urllib.parse`, `json`, `os`, `sys`, `time`, `argparse`. Match the working v2 probe at `docs/brainstorms/2026-05-04-mailstore-vm-probe-result.md`; that ~120-line script is essentially the helper.
+  - **OAUTH_TENANT default** is `common`. Microsoft routes to the user's home tenant via `login_hint`; `common` works on every tenant the user has access to. Tenant-specific endpoints (e.g. `32bffe65-3e64-414f-9d21-069572b800eb` for cullenwines.com.au, captured in the probe) are valid alternatives but offer no concrete benefit and add brittleness to tenant-rename events. Sticking with `common` matches the probe and keeps the door open for additional providers without changing helper code.
+  - `refresh` subcommand: read `OAUTH_PROVIDER`, `OAUTH_REFRESH_TOKEN`, `OAUTH_CLIENT_ID` from env (provided by systemd `EnvironmentFile`); for Gmail also `OAUTH_CLIENT_SECRET`; for O365 also `OAUTH_TENANT` (default `common`). POST to provider token endpoint with `grant_type=refresh_token`. Print only the access_token to stdout. Exit 0 on success, 1 on failure (non-zero exit causes mbsync to fail the run, which is correct).
+  - `bootstrap` subcommand: print the device-code URL + user code to stderr, poll the token endpoint, on success print a multi-line block to stdout: `OAUTH_PROVIDER=...`, `OAUTH_CLIENT_ID=...`, `OAUTH_REFRESH_TOKEN=...`, etc. Stderr carries instructions; stdout is paste-ready.
+  - O365: device-code URL `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/devicecode`, scope `offline_access https://outlook.office.com/IMAP.AccessAsUser.All`, client_id from arg or default to Thunderbird's `9e5f94bc-…`.
+  - Gmail: device-code URL `https://oauth2.googleapis.com/device/code`, scope `https://mail.google.com/`, client_id and client_secret required as args.
+  - On the Microsoft eventual-consistency quirk (probe documented this), `refresh` does not pre-emptively retry — let mbsync's next timer fire. The helper is one-shot.
+
+  **Patterns to follow:**
+  - `modules/nixos/services/podcast.nix:14-60` — `pkgs.writers.writePython3Bin` with libraries (we won't need libraries).
+  - The probe v2 script at `docs/brainstorms/2026-05-04-mailstore-vm-probe-result.md` (the authoritative shape).
+
+  **Test scenarios:**
+  - Happy path (refresh): `OAUTH_REFRESH_TOKEN=<live token> oauth2-helper refresh --provider=o365` prints a JWT-shaped string, exits 0. The token decodes to claims with `aud=https://outlook.office.com`.
+  - Happy path (bootstrap): `oauth2-helper bootstrap --provider=o365 --user=andy@cullenwines.com.au` prints a URL + code, polls, and on user sign-in prints a sops-paste-ready env block.
+  - Error path: missing `OAUTH_REFRESH_TOKEN` in env → exits non-zero with a clear stderr message.
+  - Error path: Microsoft returns `AADSTS70008` (refresh token expired) on `refresh` → exits non-zero with the AADSTS code in stderr.
+  - Edge case: HTTP timeout on token endpoint → exits non-zero, doesn't hang past 30s.
+  - Test expectation: manual exercise during U6 bootstrap; no automated tests (the probe v2 script already validated the chain end-to-end).
+
+  **Verification:**
+  - `nix-build` of the module succeeds and produces an `oauth2-helper` binary in the closure.
+  - Manual `oauth2-helper refresh --provider=o365` against a stored test refresh token returns a working access token.
+
+---
+
+- U3. **mbsync configs and per-account systemd timer + service**
+
+  **Goal:** Generate one mbsync rc per account into `/etc/mailarchive/mbsync-<account>.rc`; one oneshot systemd service per account that runs `mbsync` with the right SASL environment and on success touches the heartbeat sentinel; one timer per account.
+
+  **Requirements:** R1, R5
+
+  **Dependencies:** U1, U2.
+
+  **Files:**
+  - Modify: `modules/nixos/services/mailarchive.nix`
+
+  **Approach:**
+  - Build mbsync rc text in Nix from each account's submodule values. Use `environment.etc."mailarchive/mbsync-${name}.rc" = {text = mkMbsyncrc ...; mode = "0400"; user = "mailarchive"; group = "mailarchive";}`.
+  - mbsync rc structure (one-way Pull, archive-safe):
+    - `IMAPAccount <name>`: `Host {imap.gmail.com|outlook.office365.com}`, `User <remoteUser>`, `AuthMechs XOAUTH2`, `PassCmd "${oauth2-helper}/bin/oauth2-helper refresh --provider=${provider}"`, `SSLType IMAPS`, `PipelineDepth 1`. (Note: mbsync runs `PassCmd` via `popen()`, so the value is shell-evaluated. Nix store paths cannot contain shell metacharacters by construction, and `${provider}` interpolates an enum value (`gmail` or `o365`) — both safe. If the provider enum is ever extended to a value containing spaces, escape or pass via env.)
+    - `IMAPStore <name>-remote`: `Account <name>`.
+    - `MaildirStore <name>-local`: `Path /mnt/data/Life/Andy/Email/<name>/`, `SubFolders Verbatim`. Do **not** set an explicit `Inbox` directive — Verbatim defaults handle it under `Path`.
+    - `Channel <name>`: `Far :<name>-remote:`, `Near :<name>-local:`, `Patterns <provider-specific>`, `Sync Pull`, `Create Near`, `Remove None`, `Expunge None`, `SyncState *`. **`Sync Pull`** is the one-way semantics; `Create Near` only creates folders locally (never upstream); `Remove None` keeps local copies of server-deleted messages; `Expunge None` is the deletion-resistance.
+    - O365 `Patterns`: `"INBOX*" "Sent Items*" "Archive" "Archives*" "Drafts" "Deleted Items*" "Junk Email"` (the trailing `*` makes the pattern recursive — INBOX has 200+ subfolders per the probe). The plain `"Archive"` is defensive (some Outlook configurations use singular `Archive`; the probe showed plural `Archives` on cullenwines.com.au — `Archive` matches harmlessly if absent). Excludes `Calendar`, `Contacts`, `Tasks`, `Notes`, `Sync Issues*`, `Conversation History`, `Outbox`, `RSS Feeds`, `Templates`. Verify against the live folder tree at first run; tighten or expand the pattern list as needed.
+    - Gmail `Patterns`: `"[Gmail]/All Mail"` only.
+  - Per-account systemd service `mailarchive-<name>.service`:
+    - `Type = "oneshot"`, `User = "mailarchive"`, `Group = "mailarchive"`, `EnvironmentFile = config.sops.secrets."mailarchive/${name}".path`.
+    - `serviceConfig.Environment = "SASL_PATH=${pkgs.cyrus-sasl-xoauth2}/lib/sasl2"` — required for libsasl2 to find the XOAUTH2 plugin at runtime. systemd's `path = [...]` only sets `$PATH` and is not enough.
+    - `path = with pkgs; [ isync coreutils ]` (so `mbsync` and `touch` are on `$PATH`).
+    - `ExecStart = "${pkgs.isync}/bin/mbsync -c /etc/mailarchive/mbsync-${name}.rc -a"`.
+    - `ExecStartPost = "${pkgs.coreutils}/bin/touch /var/lib/mailarchive/${name}.heartbeat"`.
+    - `after = ["network-online.target" "mnt-data.mount"]`, `requires = ["mnt-data.mount"]`, `wants = ["network-online.target"]`.
+    - `Nice = 10`.
+  - Per-account systemd timer `mailarchive-<name>.timer`:
+    - `wantedBy = ["timers.target"]`, `OnBootSec = "2min"`, `OnUnitActiveSec = "${toString syncIntervalSec}s"`, `AccuracySec = "10s"`.
+
+  **Patterns to follow:**
+  - `modules/nixos/services/kopia.nix:239-311` — per-instance systemd services + timers with `lib.mapAttrs'`.
+  - `modules/nixos/services/kopia.nix:96-103` (`mountDepsFor`) — NFS mount dependency wiring for `/mnt/data`.
+
+  **Test scenarios:**
+  - Happy path: with bootstrapped credentials and the module enabled, `systemctl start mailarchive-work.service` runs to completion with exit 0; messages appear under `/mnt/data/Life/Andy/Email/work/INBOX/cur/`; `/var/lib/mailarchive/work.heartbeat` mtime updates.
+  - Happy path (SASL): `mbsync -V` (or first-run journal output) shows `XOAUTH2` listed in supported AuthMechs — confirms `SASL_PATH` is wired.
+  - Edge case: `EnvironmentFile` missing the refresh token → service fails fast with the `oauth2-helper` error in journal; heartbeat not touched.
+  - Edge case: `/mnt/data` is unmounted (NFS stale) → service fails to start because `requires = ["mnt-data.mount"]` won't satisfy.
+  - Error path: Microsoft returns 401 on token refresh → `mbsync` exits non-zero (PassCmd fails); journal shows the AADSTS code; heartbeat not touched (`ExecStartPost` only runs on `ExecStart` success).
+  - Integration (deletion-resistance): delete a message from O365 via OWA after it's been archived; on next mbsync run the Maildir copy stays (verifies `Sync Pull` + `Remove None` + `Expunge None`).
+  - Integration (Gmail dedup): with `Patterns "[Gmail]/All Mail"`, total Maildir message count for gmail matches Gmail's All-Mail count; no per-label duplication.
+  - Integration (no upstream pollution): create a new local Maildir folder under `work/` manually (`mkdir -p /mnt/data/Life/Andy/Email/work/Probe.NewFolder/{cur,new,tmp}`); on next mbsync run, that folder is **not** created on the live O365 server (verifies `Create Near` not `Create Both`).
+  - Test expectation: the deletion-resistance integration is the load-bearing test before retiring VM 102.
+
+  **Verification:**
+  - `mailarchive-<name>.timer` is enabled and active; `systemctl status mailarchive-<name>.timer` shows it firing every `<syncIntervalSec>`s.
+  - `/var/lib/mailarchive/<name>.heartbeat` mtime updates on each successful sync.
+  - Maildir tree under `/mnt/data/Life/Andy/Email/<name>/` is populated and matches the IMAP folder selection.
+
+---
+
+- U4. **Heartbeat HTTP server + Uptime Kuma monitor wiring (server-side boolean)**
+
+  **Goal:** A long-running systemd service that exposes `GET http://127.0.0.1:<port>/health/<account>` returning `{"healthy": true|false, "stale_seconds": <int>}`. Health is computed server-side: `healthy = stale_seconds < THRESHOLD` (default 600s). Wire one `homelab.monitoring.monitors` entry per account using `type = "json-query"` with `jsonPath = "$.healthy"`, `expectedValue = "true"`. Kuma's hardcoded `==` operator works correctly with this shape.
+
+  **Requirements:** R6
+
+  **Dependencies:** U1, U3.
+
+  **Files:**
+  - Modify: `modules/nixos/services/mailarchive.nix`
+
+  **Approach:**
+  - Define `mailarchive-health` as a second `pkgs.writers.writePython3Bin` script in the module's `let` block. Stdlib only (`http.server`, `json`, `os`, `time`, `urllib.parse`). It walks `/var/lib/mailarchive/*.heartbeat`, computes `stale_seconds = now - mtime`, and returns `{"healthy": stale_seconds < THRESHOLD, "stale_seconds": stale_seconds, "last_sync": iso8601}`. Reads `STALE_THRESHOLD_SEC` (default 600) and `HEARTBEAT_DIR` from env so it's portable.
+  - Missing heartbeat file → returns `{"healthy": false, "stale_seconds": null, "last_sync": null}` and HTTP 200 (Kuma can still json-query it).
+  - Unknown account in URL path → HTTP 404.
+  - Systemd service `mailarchive-health.service`: `Type = "simple"`, `User = "mailarchive"`, listens on `127.0.0.1:${cfg.healthPort}` (default 9876). `Restart = "on-failure"`. Includes the same `requires = ["mnt-data.mount"]` dependency since heartbeat files live under `/var/lib/` (not `/mnt/data`), but the script that reads them is harmless if heartbeats don't exist.
+  - For each account, register `homelab.monitoring.monitors`:
+    ```
+    {
+      name = "Mailarchive: <name>";
+      type = "json-query";
+      url = "http://localhost:${toString cfg.healthPort}/health/<name>";
+      jsonPath = "$.healthy";
+      expectedValue = "true";   # works with monitoring_sync.nix:201's hardcoded ==
+      interval = 60;
+      maxretries = 10;
+      retryInterval = 60;
+      resendInterval = 240;
+    }
+    ```
+    *(Honours the noise discipline defaults from `.claude/rules/nixos-service-modules.md`.)*
+  - **Two complementary gates**, by design, not redundancy:
+    - **Server-side `STALE_THRESHOLD_SEC = 600`**: flips `healthy: false` after 10 min of no successful sync. Suppresses heartbeat-clock-skew false positives; gives a meaningful answer to a manual `curl` check.
+    - **Kuma-side `interval = 60s × maxretries = 10`**: another 10 min of confirmation before paging Gotify. Suppresses HTTP-server-blip false positives (e.g. brief restart of `mailarchive-health.service`).
+    Total worst-case page latency: ~10-20 min after the underlying fetcher actually breaks. That's the right cadence for a backup-of-record. If `STALE_THRESHOLD_SEC` is changed, recompute Kuma's `maxretries` and `resendInterval` per the rule's "rebump" instructions.
+
+  **Patterns to follow:**
+  - `modules/nixos/services/kopia.nix:344-355` — json-query monitor entries (kopia uses an existing API; ours uses our own tiny server, but the registration shape is identical).
+  - `modules/nixos/services/podcast.nix` — `pkgs.writers.writePython3Bin` precedent.
+
+  **Test scenarios:**
+  - Happy path: with `mailarchive-health` running and a fresh heartbeat, `curl http://127.0.0.1:9876/health/work` returns 200 + `{"healthy": true, "stale_seconds": <small>, "last_sync": "..."}`.
+  - Edge case: heartbeat file missing (account configured but never run) → endpoint returns `{"healthy": false, "stale_seconds": null, "last_sync": null}` and Uptime Kuma marks down.
+  - Edge case: heartbeat file mtime > 600s ago → endpoint returns `healthy: false`; Uptime Kuma's json-query check fails and (after 10 retries × 60s) Gotify pings.
+  - Error path: malformed `<account>` in URL (not in configured accounts) → endpoint returns 404; Kuma marks down.
+  - Integration: stop the `mailarchive-work.timer` for >10 min → Kuma turns red and Gotify pings; restart timer → Kuma turns green within one check cycle.
+  - Integration (json-query operator): `homelab-monitoring-sync` runs successfully and the resulting Kuma monitor shows the expected `==` comparison against `"true"` (no silent fallthrough).
+
+  **Verification:**
+  - `systemctl status mailarchive-health.service` → active, serving on 127.0.0.1:9876.
+  - `curl http://127.0.0.1:9876/health/work` returns the expected JSON shape.
+  - The Mailarchive monitor appears in Uptime Kuma after the next `homelab-monitoring-sync` run and shows green when fresh heartbeats exist.
+  - Stopping the work fetcher for >10 minutes triggers a Gotify notification.
+
+---
+
+- U5. **NFS watchdog wiring**
+
+  **Goal:** Register one `homelab.nfsWatchdog` entry per account so the existing watchdog timer restarts the `mailarchive-<account>.service` if `/mnt/data` (NFS to tower) goes stale.
+
+  **Requirements:** R5
+
+  **Dependencies:** U1, U3.
+
+  **Files:**
+  - Modify: `modules/nixos/services/mailarchive.nix`
+
+  **Approach:**
+  - Inside the `config = lib.mkIf cfg.enable {...}` block, add:
+    ```
+    homelab.nfsWatchdog = lib.mapAttrs' (name: _: lib.nameValuePair "mailarchive-${name}" {
+      path = "${cfg.dataDir}/${name}";
+    }) cfg.accounts;
+    ```
+  - The watchdog's default 5-minute interval and stat-based liveness check are appropriate. It restarts the *service* (the next mbsync run picks up where it left off; mbsync's incremental sync semantics handle gaps gracefully).
+
+  **Patterns to follow:**
+  - `modules/nixos/services/kopia.nix:316-326` — exact same shape, only differs in path computation.
+  - `modules/nixos/services/nfs-watchdog.nix:42-46` — confirms the watchdog restarts `<name>.service`.
+
+  **Test scenarios:**
+  - Happy path: with `/mnt/data` healthy, the watchdog timer fires every 5 min, stats the path successfully, and does nothing.
+  - Integration: simulate a stale NFS handle (briefly stop `mnt-data.mount`); the watchdog's next stat fails with timeout, it restarts `mailarchive-work.service`; once the mount is back the next mbsync run completes.
+  - Test expectation: `systemctl status mailarchive-work-nfs-watchdog.timer` shows it active; manual trigger (`systemctl start mailarchive-work-nfs-watchdog.service`) and verify journal output.
+
+  **Verification:**
+  - Per-account watchdog units exist (`mailarchive-<name>-nfs-watchdog.{service,timer}`) and the timer is in `timers.target`.
+
+---
+
+- U6. **OAuth bootstrap runbook + ops doc** *(absorbs the original U9 — token-rotation runbook — into this single wiki entry; per the plan template's U-ID stability rule, U9 is intentionally omitted as a gap, not renumbered)*
+
+  **Goal:** A single wiki doc capturing the one-time bootstrap procedure for both work O365 and personal Gmail, plus deployment steps, the eventual-consistency callout, and operational recovery (token expiry / Microsoft client_id revocation — what was originally a separate U9). One place for "how do I work with mailarchive."
+
+  **Requirements:** R7
+
+  **Dependencies:** U2.
+
+  **Files:**
+  - Create: `docs/wiki/services/mailarchive.md`
+
+  **Approach:**
+  - The doc covers:
+    1. **Personal Gmail one-time setup**: register an OAuth client in the user's own Google Cloud project (`https://console.cloud.google.com/apis/credentials`); choose "Desktop application" type; record `client_id` and `client_secret`. From any machine with a clone of this flake (workstation works best — needs a browser):
+       ```
+       nix run github:abl030/nixosconfig#oauth2-helper -- bootstrap \
+         --provider=gmail --user=<email> \
+         --client-id=<...> --client-secret=<...>
+       ```
+       Sign in via the printed URL; helper prints the sops env block to stdout; user runs `sops -e -i secrets/hosts/doc2/mailarchive-gmail.env` and pastes the block.
+    2. **Work O365 one-time setup**: client_id is fixed (`9e5f94bc-…` Thunderbird's), no client_secret needed. Run:
+       ```
+       nix run github:abl030/nixosconfig#oauth2-helper -- bootstrap \
+         --provider=o365 --user=andy@cullenwines.com.au
+       ```
+       Sign in at `https://login.microsoft.com/device` with the printed code. Helper prints sops env block; same `sops -e -i` flow. `OAUTH_TENANT` defaults to `common` — override only if Microsoft refuses to route the auth (rare; would surface as a clear AADSTS error).
+    3. **Folder selection (O365)**: explicitly call out which folders are fetched — INBOX*, Sent Items*, Archive(s), Drafts, Deleted Items*, Junk Email — and which are excluded (Calendar, Contacts, Tasks, Notes, Sync Issues, Conversation History, Outbox, RSS Feeds, Templates). User confirms this matches their needs before deploy.
+    4. **Folder selection (Gmail)**: only `[Gmail]/All Mail` is fetched. Document why (label-vs-folder duplication).
+    5. **Deploy step**: `git push` + `ssh doc2 "sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --refresh"` (per CLAUDE.md remote-deploy rule — not `--target-host`).
+    6. **First-run quirk** (eventual-consistency): "**The very first `mailarchive-*.service` run after bootstrap may fail with `AUTHENTICATE failed` in the journal. This is *expected* — Microsoft's auth-issuer and Exchange Online's IMAP service have a few-minute consistency lag on first-auth. Do **not** re-run the bootstrap. Wait 5 minutes; the next timer fire will succeed.**" Bold the warning so a tired or anxious reader doesn't miss it.
+    7. **Verify section**: `journalctl -u mailarchive-<name>.service -n 50` confirms `Sync completed`; `curl http://127.0.0.1:9876/health/<name>` shows `healthy: true`; Uptime Kuma shows green within ~2 min.
+    8. **Token rotation / Microsoft client_id revocation recovery**: covers two operational events (incorporated from the original U9 plan):
+       - **Refresh-token expiry** (AADSTS70008 or AADSTS70043 in journal): re-run the bootstrap procedure for the affected account; sops re-encrypt; redeploy. No code changes.
+       - **Microsoft revokes Thunderbird's client_id** (precedent: 2024-08-01 retirement of `08162f7c-…`): find the new Thunderbird client_id from Mozilla's mozilla-central source; update the helper's `--client-id` default OR override per-account via `OAUTH_CLIENT_ID` in the sops env; re-bootstrap; deploy; add a dated note to this same wiki doc capturing the new id.
+
+  **Patterns to follow:**
+  - Existing wiki entries under `docs/wiki/services/` — terse, dated, with status indicators (`audiobookshelf.md`, `tdarr-node.md`, `lgtm-stack.md` are good models).
+
+  **Test scenarios:**
+  - Test expectation: none — this unit produces a documentation artifact. Quality is validated by U8's smoke test working from this doc.
+
+  **Verification:**
+  - Following the runbook from a clean state produces working refresh tokens for both accounts; no IT or admin involvement.
+
+---
+
+- U7. **MailStore Home → Maildir migration script (single legacy tree)**
+
+  **Goal:** A one-shot migration utility that converts the existing 11 GB MailStore Home archive (mixed Gmail + O365 in one MailStore repository) into Maildir, lands it under `/mnt/data/Life/Andy/Email/legacy.archive/` using the same `SubFolders Verbatim` nested-directory layout the live trees use. No per-account split.
+
+  **Requirements:** R3, R4
+
+  **Dependencies:** None for U7a/U7b (independent of U1-U5). U7c (optional dedup) is independent of U8.
+
+  **Files:**
+  - Create: `tools/mailarchive-migrate/eml-to-maildir.py`
+  - Create: `tools/mailarchive-migrate/README.md` (usage notes, including documented MailStore export path)
+
+  **Approach (three sub-steps):**
+  - **U7a — MailStore Home EML export.** On the Win VM, run MailStore Home → `Export Email` → `File system, EML format` → check `Retain folder structure` → target a path reachable from doc2 (the canonical choice: `/mnt/data/Life/Andy/Email/_mailstore-export-staging/` on a temp NFS write; document the chosen path in `tools/mailarchive-migrate/README.md`). ~11 GB output; one `.eml` file per message; folder hierarchy preserved as MailStore had it.
+  - **U7b — EML tree → Maildir conversion.** Python script (`eml-to-maildir.py`, ~60 lines using stdlib `mailbox`, `email.parser`, `os`, `pathlib`, `hashlib`, `time`):
+    - Walk the EML export tree.
+    - For each `.eml`: parse with `email.parser.BytesParser`; extract `Message-ID` (fallback: SHA-256 of first 4096 bytes as synthetic ID).
+    - Reconstruct folder hierarchy as **nested Maildir directories** matching `SubFolders Verbatim` — for an export folder `Cullen Work/INBOX/Sent Items/`, write to `legacy.archive/Cullen Work/INBOX/Sent Items/{cur,new,tmp}/`. Each level is a real subdirectory containing its own `cur/`, `new/`, `tmp/`. **Do not** flatten using Maildir++ dot-separated names (`legacy.archive/.Cullen Work.INBOX.Sent Items/`) — that would diverge from the live trees and break any future merge.
+    - Write each message to the leaf folder's `cur/` with filename pattern `<unix-timestamp>.<random>.maildir-migrate:2,S` (suffix `:2,S` marks as already-seen; mbsync won't re-flag them if they ever get merged).
+    - Track `Message-ID` set in memory; on collision within the same export, skip and log.
+    - Output Maildir tree at `/mnt/data/Life/Andy/Email/legacy.archive/`.
+    - Print stats: `<N> messages written, <M> duplicates skipped, <K> folders created`.
+  - **U7c — Optional dedup against live trees.** Independent of cutover. If after the live `o365/` and `gmail/` trees have populated, the user wants to merge legacy into live and drop overlap (messages MailStore captured that O365 still has on the server, also fetched by the live mbsync), run a small inline Python script (~30 lines, stdlib only): walk both trees, build a `Message-ID → filepath` map keyed off `email.parser.BytesParser`, on collision delete the older file. `maildir-deduplicate` / `mail-deduplicate` are **not** packaged in nixpkgs (verified) — the inline script is the canonical path. The dedup is genuinely optional; keeping `legacy.archive/` separate forever is also fine and arguably safer (no risk of merge corruption). **Default recommendation: leave separate.** Only run dedup if the user explicitly wants a single unified tree.
+
+  **Patterns to follow:**
+  - `tools/` directory convention — the closest existing one-shot script in the repo, mirror its README/CLI shape.
+  - `modules/nixos/services/podcast.nix` — `pkgs.writers.writePython3Bin` precedent if we package the script as a flake app instead of a loose `.py`.
+
+  **Test scenarios:**
+  - Happy path (U7b): given a small known-good EML tree (handful of messages with attachments, nested folders), the script produces a valid nested Maildir; opening the leaf folder in Thunderbird (point it at a local-folder path) shows messages with intact attachments.
+  - Happy path (U7b): the produced layout matches `SubFolders Verbatim` — `find legacy.archive -type d -name cur | head` shows nested paths like `legacy.archive/Cullen Work/INBOX/cur`, not `legacy.archive/.Cullen Work.INBOX/cur`.
+  - Edge case (U7b): EML files missing `Message-ID` header → fallback synthetic ID is generated and applied consistently for that file (so a re-run produces the same ID).
+  - Edge case (U7b): folder names with spaces or special characters → preserved verbatim in the directory names (consistent with mbsync's Verbatim mode).
+  - Error path (U7b): one corrupt EML in the tree → script logs the file and continues, doesn't abort the whole migration.
+  - Edge case (U7c): if run, `maildir-deduplicate` correctly removes duplicates by Message-ID across `legacy.archive/` and live trees, keeping the live-fetched copy.
+  - Test expectation: dry-run on a 100-message subset of the real archive before running on the full 11 GB.
+
+  **Verification:**
+  - After U7b: `find /mnt/data/Life/Andy/Email/legacy.archive -name 'cur' -type d | wc -l` matches the original folder count; total message count matches the script's output stats.
+  - After U7b: opening the Maildir in any standard client (Thunderbird, mu, mutt) shows the historical archive intact.
+
+---
+
+- U8. **Host enablement on doc2 + smoke test + VM 102 retirement**
+
+  **Goal:** Enable the module on doc2, complete the bootstrap, smoke-test against real messages, stop VM 102, and destroy it after a short safety window.
+
+  **Requirements:** R8
+
+  **Dependencies:** U1-U6 deployed; U7a + U7b complete (the historical archive can be migrated before, during, or after — independent).
+
+  **Files:**
+  - Modify: `hosts/doc2/configuration.nix` (add `homelab.services.mailarchive` block)
+  - Create: `secrets/hosts/doc2/mailarchive-work.env` (sops-encrypted, populated via U6)
+  - Create: `secrets/hosts/doc2/mailarchive-gmail.env` (sops-encrypted, populated via U6)
+
+  **Approach:**
+  - **Step 1 — enable on doc2.** Add to `hosts/doc2/configuration.nix`:
+    ```
+    homelab.services.mailarchive = {
+      enable = true;
+      dataDir = "/mnt/data/Life/Andy/Email";
+      accounts = {
+        work = { provider = "o365"; remoteUser = "andy@cullenwines.com.au"; credentialSecret = "mailarchive/work"; syncIntervalSec = 60; };
+        gmail = { provider = "gmail"; remoteUser = "<personal-gmail>"; credentialSecret = "mailarchive/gmail"; syncIntervalSec = 120; };
+      };
+    };
+    ```
+  - **Step 2 — bootstrap secrets** per the U6 wiki doc. Push to GitHub.
+  - **Step 3 — deploy.** `git push` then `ssh doc2 "sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --refresh"`. Per CLAUDE.md, never use `--target-host`.
+  - **Step 4 — smoke test (live).** Per U6's eventual-consistency note, the very first sync may fail; wait 5 min before judging. Then:
+    - Send a test email from another account to the work address; within 60s, confirm it lands in `/mnt/data/Life/Andy/Email/work/INBOX/cur/` (or under whichever folder Outlook's rules drop it into).
+    - Send a test email to the personal Gmail; within 120s, confirm it appears in `/mnt/data/Life/Andy/Email/gmail/[Gmail]/All Mail/cur/`.
+    - Delete one of the test messages from the live server (OWA / Gmail web). Manually trigger another sync (`systemctl start mailarchive-work.service`). Confirm: (a) the service exits 0; (b) the Maildir copy is untouched; (c) `journalctl -u mailarchive-work.service -n 50` shows no `UID gap`, `message lost`, or similar warnings. Repeat the sync 3-4 times to ensure mbsync's incremental state file (`SyncState`) tolerates the gap. This exercises the rc's one-way semantics AND mbsync's state-tracking — under a misconfigured `Sync All` + `Remove Both` rc the local copy would disappear (test failure); under correct `Sync Pull` + `Remove None` it stays.
+    - Both Uptime Kuma monitors are green; `journalctl -u mailarchive-work.service -n 20` shows successful `Sync completed`.
+  - **Step 5 — stop VM 102.** Once smoke test passes: `vms/proxmox-ops.sh stop 102` (per CLAUDE.md: never run Proxmox commands directly).
+  - **Step 6 — safety window.** Wait ~3-5 days with VM 102 stopped. The disks remain on `nvmeprom`; if any issue surfaces in the new fetcher, restart 102 and investigate. No further action needed during this window — just observe Kuma stays green and journal is quiet.
+  - **Step 7 — destroy VM 102.** `vms/proxmox-ops.sh destroy 102`. Verify with `vms/proxmox-ops.sh list` that 102 is gone.
+  - **Step 8 — clean up.** Remove `_mailstore-export-staging/` if it was on shared storage. VM 102 was never inventoried in `hosts.nix`, `vms/tofu/vm-resources.nix`, or any other fleet-config file (Proxmox-side-only VM created by hand) — no fleet config changes needed. Optionally file an issue to update the stale `vms/definitions.nix` reference in CLAUDE.md.
+
+  **Patterns to follow:**
+  - `vms/proxmox-ops.sh` — ALL Proxmox commands go through it (CLAUDE.md rule). Verify the wrapper supports `stop` and `destroy` verbs at implementation time; if not, extend it rather than reaching past it.
+  - `hosts/doc2/configuration.nix` — match existing `homelab.services.*` block style.
+
+  **Test scenarios:**
+  - Happy path (smoke): test email lands in Maildir within one sync cycle; both Kuma monitors are green.
+  - Happy path (deletion-resistance): test email deleted from live server stays in Maildir.
+  - Error path (deploy): `nixos-rebuild switch` fails due to module bug → revert the host config change and re-deploy; the module's `enable = false` path keeps the system clean.
+  - Integration: full chain — Microsoft sends new email → mbsync timer fires within 60s → message lands in `o365/INBOX/cur/` → heartbeat sentinel touched → Uptime Kuma shows green → Kopia's next snapshot picks up the new message.
+  - Error path (destroy): `vms/proxmox-ops.sh destroy 102` fails or doesn't support destroy → stop here and check the wrapper script; do not reach for `qm destroy` directly.
+  - Test expectation: smoke test is the validation. No "2-week parallel run" — once smoke test passes and the safety window elapses, retirement proceeds.
+
+  **Verification:**
+  - Both Uptime Kuma monitors green.
+  - Test messages flowed end-to-end and survived a deletion test.
+  - `vms/proxmox-ops.sh list` no longer shows VM 102.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** mbsync → `oauth2-helper` (PassCmd) → Microsoft/Google token endpoints → Microsoft/Google IMAP servers → Maildir on `/mnt/data` (NFSv4.2 from tower / Unraid). Heartbeat sentinel → `mailarchive-health` HTTP server → Uptime Kuma's existing `homelab-monitoring-sync` flow. NFS watchdog timer → systemd → `mailarchive-<name>.service`. No direct interactions with other services on doc2.
+- **Error propagation:** mbsync exit non-zero → systemd marks service failed → heartbeat NOT touched (`ExecStartPost` only runs on success) → Uptime Kuma sees `healthy: false` after ≥600s → after `maxretries × retryInterval` confirmation window → Gotify pings. NFS staleness → watchdog catches via stat timeout → restarts service.
+- **State lifecycle risks:** `Sync Pull` + `Remove None` + `Expunge None` keep deleted-on-server messages in Maildir — that's the intended deletion-resistance, not a leak. If the user wants to ever expire archive messages, that's a separate manual step. mbsync writes to `tmp/` and renames to `new/`/`cur/` atomically, no partial-write risk.
+- **API surface parity:** `homelab.services.mailarchive` adds new options namespace; existing services unaffected. `homelab.monitoring.monitors` gets two new entries; `homelab.nfsWatchdog` gets two new entries.
+- **Integration coverage:** the smoke test in U8 is the integration test. Verifies the full chain end-to-end with real messages, real IMAP, real refresh tokens, real NFS, real Kuma, real Gotify, plus a deliberate deletion-resistance probe.
+- **Hidden constraint — Kuma host co-location.** The monitor URL `http://localhost:${healthPort}/health/<account>` only works because Uptime Kuma and `mailarchive-health` are both on doc2. If Kuma ever moves hosts (precedent: services have moved between doc1/doc2 historically), this monitor will silently break — Kuma will probe `localhost:9876` from its new host and find nothing. The same fleet-wide constraint already applies to kopia's json-query monitors at `http://localhost:51515/...`; it's a known posture, not a new bug. Document and accept; revisit only if Kuma ever moves.
+- **Unchanged invariants:** Kopia's snapshot job for `/mnt/data` already picks up everything under it; no change to `kopia.nix`. Existing `homelab.localProxy`/`homelab.tailscaleShare` not used here (the module exposes only a localhost-bound health endpoint). VM 102 stays runnable until U8 step 7.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Microsoft revokes Thunderbird's client_id mid-deployment, breaking ingest. | U6 runbook makes recovery a documented ~30-min operation. Uptime Kuma + Gotify catches it within 10-12 min of failure. |
+| Refresh token expires unexpectedly (e.g., admin-side conditional access policy change). | U6 runbook covers re-bootstrap; one operation. |
+| `Sync Pull` config error allowing accidental two-way sync, polluting the live mailbox. | Test in U3 deliberately verifies (a) deleted-from-server messages stay in Maildir and (b) local-only folders are NOT created upstream. Both must pass before the smoke test in U8. |
+| `cyrus-sasl-xoauth2` SASL plugin not loaded by mbsync because of `SASL_PATH` not being set. | U3 sets `Environment = "SASL_PATH=..."` explicitly. Verify at first run that `mbsync -V` lists XOAUTH2 in supported AuthMechs. The probe v2 script bypassed mbsync (raw IMAP), so this is the first time we exercise the SASL path. |
+| MailStore EML export loses headers or attachments. | Spot-check 5 messages across categories (plain text, HTML, with-attachment, multi-recipient, calendar invite) before running U7b on the full 11 GB. |
+| 11 GB Maildir stresses Kopia's first-snapshot performance. | Acceptable — Kopia handles much larger trees, and EMLs are highly dedup-friendly (RFC822 has lots of common header structure). Run U7b at a quiet hour if concerned; subsequent snapshots are incremental. |
+| `/mnt/data` NFS goes stale and causes message loss between watchdog cycles. | 5-min watchdog interval + 60s mbsync timer + mbsync's incremental sync semantics: gaps are recoverable; no data loss because we never delete locally. |
+| Microsoft eventual-consistency quirk causes day-1 false alarms. | U6 runbook calls this out explicitly with a bolded warning; user is told to wait 5 min after first bootstrap. |
+| Gmail folder selection wrong (e.g. Patterns matches more than All Mail). | U3's folder-selection test verifies total Maildir message count against Gmail's All-Mail count; mismatch = pattern wrong. |
+| Uptime Kuma migrates to a different host post-deployment. | Localhost monitor URL constraint documented in System-Wide Impact. If Kuma moves, swap monitor URLs to `http://doc2.lan:9876/...` (or use localProxy) at that time. Same posture as kopia. |
+
+---
+
+## Documentation / Operational Notes
+
+- New wiki entry: `docs/wiki/services/mailarchive.md` (U6) — bootstrap, deploy, troubleshoot, token rotation. Reference it from the module's header comment.
+- After deployment, the wiki entry captures: deployment date, the working Thunderbird client_id at deployment time, the cullenwines.com.au tenant ID, the GCP project ID for personal Gmail (link). This is the institutional record per CLAUDE.md's wiki rules.
+- After VM 102 retirement (U8 step 7), VM 102 was never in fleet-config inventory — no `hosts.nix`, `vms/tofu/`, or `vms/definitions.nix` updates needed (the latter doesn't exist; CLAUDE.md's "Important Files" list is stale on this point and could be cleaned up in a separate pass).
+- No external docs (Cloudflare, ingress, etc.) need updating — the service exposes nothing public.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-04-mailstore-vm-replacement-requirements.md](../brainstorms/2026-05-04-mailstore-vm-replacement-requirements.md)
+- **Companion research:** [docs/brainstorms/2026-05-04-mailstore-vm-replacement-research.md](../brainstorms/2026-05-04-mailstore-vm-replacement-research.md) (per-tool comparison; architecture-2 recommendation now superseded by probe)
+- **Probe result:** [docs/brainstorms/2026-05-04-mailstore-vm-probe-result.md](../brainstorms/2026-05-04-mailstore-vm-probe-result.md) — end-to-end verification of Architecture 1 against the live work tenant
+- **Plan review (round 1):** [docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan-REVIEW.md](2026-05-04-001-feat-mailarchive-mailstore-retirement-plan-REVIEW.md) — independent review that surfaced 3 critical bugs and 9 should-fixes integrated into this revision
+- **Plan review (round 2):** [docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan-REVIEW-2.md](2026-05-04-001-feat-mailarchive-mailstore-retirement-plan-REVIEW-2.md) — verification pass on the rewrite; surfaced N-C1 (`maildir-deduplicate` not in nixpkgs) and 5 should-fixes, all integrated
+- **Pattern reference:** `modules/nixos/services/kopia.nix` (closest module shape match)
+- **Service module rules:** `.claude/rules/nixos-service-modules.md`
+- **NFS watchdog:** `modules/nixos/services/nfs-watchdog.nix`
+- **NFS mount:** `modules/nixos/services/mounts/nfs-local.nix` (confirms `/mnt/data` is NFSv4.2 to tower, not virtiofs)
+- **Monitoring sync:** `modules/nixos/services/monitoring_sync.nix:201` (json-query operator hardcoded `==` — drives the server-side boolean shape in U4)
+- **Sops path resolution:** `modules/nixos/common/secrets.nix:35` (confirms `secrets/hosts/<hostname>/` search path)
+- **Python helper precedent:** `modules/nixos/services/podcast.nix` (`pkgs.writers.writePython3Bin` shape)
+- **VM ops:** `vms/proxmox-ops.sh` (CLAUDE.md mandates all Proxmox operations through this wrapper)
+- **External:** [Mozilla Thunderbird OAuth KB](https://support.mozilla.org/en-US/kb/microsoft-oauth-authentication-and-thunderbird-202)
+- **External:** [moriyoshi/cyrus-sasl-xoauth2 README](https://github.com/moriyoshi/cyrus-sasl-xoauth2) — `SASL_PATH` env var requirement
+- **External:** [DavMail RELEASE-NOTES.md](https://github.com/mguessan/davmail/blob/master/RELEASE-NOTES.md) (for tracking auth-tightening events that may also affect us)

--- a/docs/wiki/services/mailarchive.md
+++ b/docs/wiki/services/mailarchive.md
@@ -1,0 +1,210 @@
+# Mail archival (mailarchive)
+
+**Last researched:** 2026-05-04
+**Status:** built and merged; pending bootstrap + first sync on doc2
+**Host:** `doc2`
+**Module:** `modules/nixos/services/mailarchive.nix`
+**Plan:** `docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan.md`
+
+## What this is
+
+`homelab.services.mailarchive` continuously pulls Gmail and work O365
+(`cullenwines.com.au`) into Maildir under
+`/mnt/data/Life/Andy/Email/<account>/`. Replaces the Win10 MailStore VM
+(VMID 102 — to be retired once the smoke test passes).
+
+Posture: backup-of-record. mbsync is configured `Sync Pull` + `Create
+Near` + `Remove None` + `Expunge None`, so server-side deletions never
+propagate to the local archive. New folders cannot be created on the
+remote by mbsync.
+
+## One-time bootstrap
+
+Run from any machine with this flake checked out and a browser
+(workstation works best). Bootstrap is needed once per account and once
+again whenever Microsoft revokes the refresh token (~90 days inactive,
+or earlier if a Conditional Access policy changes).
+
+### Personal Gmail
+
+1. **Register an OAuth client** in your own Google Cloud project:
+   <https://console.cloud.google.com/apis/credentials>. Type:
+   "Desktop application". Record the `client_id` and `client_secret`.
+2. **Run the bootstrap helper:**
+
+   ```bash
+   nix run github:abl030/nixosconfig#oauth2-helper -- bootstrap \
+     --provider=gmail --user=<your.gmail@gmail.com> \
+     --client-id=<gcp-client-id> --client-secret=<gcp-client-secret>
+   ```
+
+3. The helper prints a URL + code on stderr. Sign in via that URL.
+4. On success it prints a paste-ready dotenv block on stdout. Save it:
+
+   ```bash
+   sops -e -i secrets/hosts/doc2/mailarchive-gmail.env
+   # (file opens in $EDITOR; paste the printed block; :wq)
+   git add secrets/hosts/doc2/mailarchive-gmail.env
+   git commit -m "feat(mailarchive): seed gmail refresh token"
+   git push
+   ```
+
+### Work O365 (cullenwines.com.au)
+
+The work tenant has Thunderbird's published OAuth client_id pre-consented
+(`9e5f94bc-e8a4-4e73-b8be-63364c29d753`, app object id
+`ffa49eb9-9ee2-4ac1-9207-e05cf008015a`). No app registration required.
+DavMail's client_id is **not** consented and would need an admin ticket —
+the probe (`docs/brainstorms/2026-05-04-mailstore-vm-probe-result.md`)
+ruled out DavMail for that reason.
+
+```bash
+nix run github:abl030/nixosconfig#oauth2-helper -- bootstrap \
+  --provider=o365 --user=andy@cullenwines.com.au
+```
+
+Sign in at <https://login.microsoft.com/device> with the printed code.
+Tenant defaults to `common` — Microsoft routes by `login_hint`. Override
+with `--tenant=<id>` only if `common` refuses to route (rare; would
+surface as a clear AADSTS error).
+
+Save the printed block to `secrets/hosts/doc2/mailarchive-work.env`:
+
+```bash
+sops -e -i secrets/hosts/doc2/mailarchive-work.env
+git commit && git push
+```
+
+## Enable on doc2
+
+The host config in `hosts/doc2/configuration.nix` already declares the
+two accounts but ships with `enable = false;` so initial deploys don't
+break on missing secrets. After both
+`secrets/hosts/doc2/mailarchive-work.env` and
+`secrets/hosts/doc2/mailarchive-gmail.env` exist (encrypted via the
+bootstrap flow above), flip `enable = false;` → `enable = true;` in the
+host config:
+
+```nix
+homelab.services.mailarchive = {
+  enable = true;  # ← flip here
+  accounts = { ... };
+};
+```
+
+Commit and push.
+
+## Deploy
+
+Per `CLAUDE.md`: never use `--target-host` for remote rebuilds. The host
+pulls from GitHub:
+
+```bash
+ssh doc2 "sudo nixos-rebuild switch \
+  --flake github:abl030/nixosconfig#doc2 --refresh"
+```
+
+`--refresh` forces nix to re-resolve the flake ref so the latest push is
+picked up.
+
+## First-run quirk: Microsoft eventual consistency
+
+> **The very first `mailarchive-work.service` run after bootstrap may
+> fail with `AUTHENTICATE failed.` in the journal. This is *expected*.
+> Microsoft's auth-issuer and Exchange Online's IMAP service have a
+> few-minute consistency lag on first-auth. Do NOT re-run the bootstrap.
+> Wait 5 minutes; the next timer fire will succeed.**
+
+The probe documented this on 2026-05-04 — first attempt failed
+immediately after consent, retry ~5 minutes later succeeded. In normal
+operation (refresh-only auths) this never recurs.
+
+## Verify
+
+```bash
+# Service status + recent journal
+ssh doc2 systemctl status mailarchive-work.service mailarchive-gmail.service
+ssh doc2 'journalctl -u mailarchive-work.service -n 50'
+
+# Health endpoint (server-side boolean)
+ssh doc2 'curl -s http://127.0.0.1:9876/health/work | jq'
+ssh doc2 'curl -s http://127.0.0.1:9876/health/gmail | jq'
+# → {"healthy": true, "stale_seconds": <small>, "last_sync": "..."}
+
+# Maildir populated
+ssh doc2 'find /mnt/data/Life/Andy/Email/work/INBOX/cur -type f | head'
+ssh doc2 'find /mnt/data/Life/Andy/Email/gmail -type d -name cur | head'
+```
+
+Uptime Kuma should show two new monitors green within ~2 minutes of the
+`homelab-monitoring-sync` job picking them up.
+
+## Folder selection
+
+### O365
+
+`Patterns "INBOX*" "Sent Items*" "Archive" "Archives*" "Drafts" "Deleted Items*" "Junk Email"`
+
+The trailing `*` makes a pattern recursive. The probe showed 332 folders
+on cullenwines.com.au (deeply nested under INBOX). Excluded:
+`Calendar`, `Contacts`, `Tasks`, `Notes`, `Sync Issues*`,
+`Conversation History`, `Outbox`, `RSS Feeds`, `Templates` — these are
+calendar/state folders, not mail.
+
+Verify against the live folder tree at first run; tighten or expand
+`folderPatterns` in `hosts/doc2/configuration.nix` as needed.
+
+### Gmail
+
+`Patterns "[Gmail]/All Mail"` only. Gmail's IMAP exposes labels as
+folders and every message appears in every folder it's labelled with.
+Fetching by label would multiply messages by N. `[Gmail]/All Mail`
+contains every message exactly once — the canonical backup target.
+
+## Operational recovery
+
+### Refresh-token expiry (AADSTS70008 / AADSTS70043)
+
+Symptoms: `mailarchive-<account>.service` starts failing; journal shows
+the AADSTS code from `oauth2-helper`. Heartbeat stops updating; Kuma
+turns red after ~10-20 minutes.
+
+Fix: re-run the bootstrap procedure for the affected account, re-encrypt
+the secret, redeploy. No code changes.
+
+### Microsoft revokes the Thunderbird client_id
+
+Precedent: 2024-08-01 retirement of `08162f7c-…`. Recovery is documented
+but happens out-of-band:
+
+1. Find the new Thunderbird client_id from Mozilla's `mozilla-central`
+   sources (search for the OAuth issuer config).
+2. Update the helper's default in `nix/pkgs/oauth2-helper.nix`
+   (`THUNDERBIRD_O365_CLIENT_ID`) **or** override per-account by setting
+   `OAUTH_CLIENT_ID=<new-id>` in the sops dotenv.
+3. Re-bootstrap, redeploy.
+4. **Append a dated note to this wiki entry** capturing the new id and
+   the date Microsoft retired the old one — that's the institutional
+   record for the next rotation.
+
+Total recovery time: ~30-60 minutes per account.
+
+### NFS to tower goes stale
+
+The `homelab.nfsWatchdog` registers one watchdog per account at
+`${dataDir}/${name}`. Stat-check every 5 min; on timeout, restarts the
+fetcher service. mbsync's incremental sync semantics tolerate the gap.
+
+If the mount is stuck for longer than that, check tower (`192.168.1.2`)
+NFS export status and the `mnt-data.mount` unit on doc2.
+
+## Architecture references
+
+- Plan: `docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan.md`
+- Probe (end-to-end verification of OAuth + IMAP):
+  `docs/brainstorms/2026-05-04-mailstore-vm-probe-result.md`
+- Tool comparison (mbsync vs getmail6 vs OfflineIMAP, MailStore migration
+  mechanics): `docs/brainstorms/2026-05-04-mailstore-vm-replacement-research.md`
+- `cyrus-sasl-xoauth2` `SASL_PATH` requirement:
+  <https://github.com/moriyoshi/cyrus-sasl-xoauth2>
+- Migration tool (MailStore EML → Maildir): `tools/mailarchive-migrate/`

--- a/hosts/doc2/configuration.nix
+++ b/hosts/doc2/configuration.nix
@@ -179,6 +179,26 @@
       domain-monitor.enable = true;
       forgejo.enable = true;
       rtrfm-nowplaying.enable = true;
+      # Mail archival — replaces Win10 MailStore VM (VMID 102).
+      # Two accounts: personal Gmail and work O365 (cullenwines.com.au).
+      # Bootstrap procedure (per-account refresh tokens, sops env files):
+      #   docs/wiki/services/mailarchive.md
+      # After both secrets/hosts/doc2/mailarchive-{work,gmail}.env exist,
+      # flip `enable = true;` and redeploy.
+      mailarchive = {
+        enable = false;
+        accounts = {
+          work = {
+            provider = "o365";
+            remoteUser = "andy@cullenwines.com.au";
+          };
+          gmail = {
+            provider = "gmail";
+            remoteUser = "abl030@gmail.com";
+          };
+        };
+      };
+
       kopia = {
         enable = true;
         dataDir = "/mnt/virtio/kopia";

--- a/modules/nixos/services/default.nix
+++ b/modules/nixos/services/default.nix
@@ -46,6 +46,7 @@
     ./youtarr.nix
     ./musicbrainz.nix
     ./kopia.nix
+    ./mailarchive.nix
     ./meelo.nix
     ./domain-monitor.nix
     ./forgejo.nix

--- a/modules/nixos/services/mailarchive.nix
+++ b/modules/nixos/services/mailarchive.nix
@@ -1,0 +1,385 @@
+# Mail archival via mbsync + cyrus-sasl-xoauth2 + a small Python OAuth helper.
+#
+# Replaces the Win10 MailStore VM with a NixOS-native fetcher that pulls
+# Gmail and O365 (cullenwines.com.au) into Maildir under
+# /mnt/data/Life/Andy/Email/<account>/. Backup-of-record posture:
+# Sync Pull, Create Near, Remove None, Expunge None — server-side
+# deletions never propagate to the local archive.
+#
+# Runbook: docs/wiki/services/mailarchive.md
+# Plan:    docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan.md
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.homelab.services.mailarchive;
+
+  # OAuth2 helper — same definition exported by nix/devshell.nix as the
+  # `oauth2-helper` flake app, so the bootstrap and runtime refresh paths
+  # share one binary.
+  oauth2Helper = import ../../../nix/pkgs/oauth2-helper.nix {inherit pkgs;};
+
+  # Heartbeat HTTP server. Reads /var/lib/mailarchive/<account>.heartbeat
+  # mtimes and serves a server-side boolean `healthy` flag. The
+  # server-side boolean is required because monitoring_sync.nix hardcodes
+  # the json-query operator to `==` — a client-side `<600` comparator would
+  # silently fail. See plan §"Heartbeat via pull/json-query with server-side
+  # boolean".
+  healthServer =
+    pkgs.writers.writePython3Bin "mailarchive-health" {
+      flakeIgnore = ["E501"];
+    } ''
+      """Tiny HTTP server reporting per-account fetcher freshness."""
+
+      import datetime
+      import json
+      import os
+      import sys
+      from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+      HOST = os.environ.get("BIND_HOST", "127.0.0.1")
+      PORT = int(os.environ.get("BIND_PORT", "9876"))
+      HEARTBEAT_DIR = os.environ.get("HEARTBEAT_DIR", "/var/lib/mailarchive")
+      THRESHOLD = int(os.environ.get("STALE_THRESHOLD_SEC", "600"))
+      ACCOUNTS = set(filter(None, os.environ.get("ACCOUNTS", "").split(",")))
+
+
+      def health_for(account):
+          path = os.path.join(HEARTBEAT_DIR, f"{account}.heartbeat")
+          try:
+              mtime = os.path.getmtime(path)
+          except FileNotFoundError:
+              return {"healthy": False, "stale_seconds": None, "last_sync": None}
+          import time
+          stale = int(time.time() - mtime)
+          return {
+              "healthy": stale < THRESHOLD,
+              "stale_seconds": stale,
+              "last_sync": datetime.datetime.fromtimestamp(mtime, datetime.timezone.utc).isoformat(),
+          }
+
+
+      class Handler(BaseHTTPRequestHandler):
+          def log_message(self, *_args):  # quiet
+              return
+
+          def do_GET(self):
+              parts = self.path.strip("/").split("/")
+              if len(parts) == 2 and parts[0] == "health":
+                  account = parts[1]
+                  if account not in ACCOUNTS:
+                      self.send_response(404)
+                      self.send_header("Content-Type", "application/json")
+                      self.end_headers()
+                      self.wfile.write(json.dumps({"error": "unknown account"}).encode())
+                      return
+                  body = json.dumps(health_for(account)).encode()
+                  self.send_response(200)
+                  self.send_header("Content-Type", "application/json")
+                  self.send_header("Content-Length", str(len(body)))
+                  self.end_headers()
+                  self.wfile.write(body)
+                  return
+              self.send_response(404)
+              self.end_headers()
+
+
+      def main():
+          srv = ThreadingHTTPServer((HOST, PORT), Handler)
+          sys.stderr.write(f"mailarchive-health: listening on {HOST}:{PORT}, accounts={sorted(ACCOUNTS)}\n")
+          srv.serve_forever()
+
+
+      if __name__ == "__main__":
+          main()
+    '';
+
+  defaultGmailFolders = ["[Gmail]/All Mail"];
+  defaultO365Folders = [
+    "INBOX*"
+    "Sent Items*"
+    "Archive"
+    "Archives*"
+    "Drafts"
+    "Deleted Items*"
+    "Junk Email"
+  ];
+
+  # IMAP host per provider.
+  imapHostFor = provider: let
+    hosts = {
+      gmail = "imap.gmail.com";
+      o365 = "outlook.office365.com";
+    };
+  in
+    hosts.${provider};
+
+  # Render an mbsync rc for a single account. Backup-of-record posture:
+  # `Sync Pull` (one-way, server → local), `Create Near` (don't pollute the
+  # remote with locally-created folders), `Remove None` + `Expunge None`
+  # (server-side deletions never propagate locally — deletion-resistance).
+  mkMbsyncRc = name: acct: let
+    quotedPatterns =
+      lib.concatStringsSep " " (map (p: "\"${p}\"") acct.folderPatterns);
+  in ''
+    IMAPAccount ${name}
+    Host ${imapHostFor acct.provider}
+    User ${acct.remoteUser}
+    AuthMechs XOAUTH2
+    PassCmd "${oauth2Helper}/bin/oauth2-helper refresh --provider=${acct.provider}"
+    SSLType IMAPS
+    PipelineDepth 1
+
+    IMAPStore ${name}-remote
+    Account ${name}
+
+    MaildirStore ${name}-local
+    Path ${cfg.dataDir}/${name}/
+    SubFolders Verbatim
+
+    Channel ${name}
+    Far :${name}-remote:
+    Near :${name}-local:
+    Patterns ${quotedPatterns}
+    Sync Pull
+    Create Near
+    Remove None
+    Expunge None
+    SyncState *
+  '';
+
+  accountModule = lib.types.submodule ({
+    name,
+    config,
+    ...
+  }: {
+    options = {
+      provider = lib.mkOption {
+        type = lib.types.enum ["gmail" "o365"];
+        description = "Mail provider — drives OAuth flow specifics and folder defaults.";
+      };
+
+      remoteUser = lib.mkOption {
+        type = lib.types.str;
+        description = "Remote IMAP user (full email address).";
+      };
+
+      syncIntervalSec = lib.mkOption {
+        type = lib.types.int;
+        default =
+          if config.provider == "o365"
+          then 60
+          else 120;
+        defaultText = lib.literalExpression "60 for o365, 120 for gmail";
+        description = "Seconds between mbsync runs.";
+      };
+
+      credentialSecret = lib.mkOption {
+        type = lib.types.str;
+        default = "mailarchive/${name}";
+        defaultText = lib.literalExpression "mailarchive/<account>";
+        description = ''
+          sops secret name. Defaults to "mailarchive/<account>" — the
+          per-account dotenv must contain OAUTH_REFRESH_TOKEN, OAUTH_CLIENT_ID,
+          and (Gmail only) OAUTH_CLIENT_SECRET.
+        '';
+      };
+
+      folderPatterns = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default =
+          if config.provider == "gmail"
+          then defaultGmailFolders
+          else defaultO365Folders;
+        defaultText = lib.literalExpression ''
+          gmail → ["[Gmail]/All Mail"]
+          o365  → ["INBOX*" "Sent Items*" "Archive" "Archives*" "Drafts" "Deleted Items*" "Junk Email"]
+        '';
+        description = ''
+          mbsync Patterns directive — list of patterns to fetch. Trailing `*`
+          makes a pattern recursive. Gmail's default fetches All Mail only
+          (Gmail labels-as-folders multiplies messages per label, so the
+          canonical backup target is `[Gmail]/All Mail`).
+        '';
+      };
+    };
+  });
+in {
+  options.homelab.services.mailarchive = {
+    enable = lib.mkEnableOption "Mail archival via mbsync + XOAUTH2";
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/mnt/data/Life/Andy/Email";
+      description = "Base directory for per-account Maildir trees.";
+    };
+
+    healthPort = lib.mkOption {
+      type = lib.types.port;
+      default = 9876;
+      description = "Localhost port for the mailarchive-health server.";
+    };
+
+    staleThresholdSec = lib.mkOption {
+      type = lib.types.int;
+      default = 600;
+      description = ''
+        Seconds since last successful sync before /health/<account> reports
+        healthy=false. Pairs with Uptime Kuma's maxretries × interval to give
+        ~10-20 min total page latency for a stuck fetcher.
+      '';
+    };
+
+    accounts = lib.mkOption {
+      type = lib.types.attrsOf accountModule;
+      default = {};
+      description = "Per-account fetcher configuration.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Static system user — needs NFS write access to /mnt/data via users group.
+    users.users.mailarchive = {
+      isSystemUser = true;
+      group = "mailarchive";
+      home = "/var/lib/mailarchive";
+      createHome = false;
+      extraGroups = ["users"];
+    };
+    users.groups.mailarchive = {};
+
+    sops.secrets =
+      lib.mapAttrs' (
+        name: _:
+          lib.nameValuePair "mailarchive/${name}" {
+            sopsFile = config.homelab.secrets.sopsFile "mailarchive-${name}.env";
+            format = "dotenv";
+            owner = "mailarchive";
+            mode = "0400";
+          }
+      )
+      cfg.accounts;
+
+    # mbsync rc files. mbsync runs PassCmd via popen() so the rendered string
+    # is shell-evaluated — Nix store paths and the provider enum are safe.
+    environment.etc =
+      lib.mapAttrs' (
+        name: acct:
+          lib.nameValuePair "mailarchive/mbsync-${name}.rc" {
+            text = mkMbsyncRc name acct;
+            mode = "0400";
+            user = "mailarchive";
+            group = "mailarchive";
+          }
+      )
+      cfg.accounts;
+
+    systemd = {
+      tmpfiles.rules =
+        [
+          "d /var/lib/mailarchive 0700 mailarchive mailarchive - -"
+        ]
+        ++ (lib.mapAttrsToList (
+            name: _: "d ${cfg.dataDir}/${name} 0700 mailarchive mailarchive - -"
+          )
+          cfg.accounts);
+
+      services =
+        (lib.mapAttrs' (
+            name: _:
+              lib.nameValuePair "mailarchive-${name}" {
+                description = "Mail archival fetcher (${name})";
+                after = ["network-online.target" "mnt-data.mount"];
+                requires = ["mnt-data.mount"];
+                wants = ["network-online.target"];
+
+                path = with pkgs; [isync coreutils];
+                serviceConfig = {
+                  Type = "oneshot";
+                  User = "mailarchive";
+                  Group = "mailarchive";
+                  # libsasl2 finds plugins via SASL_PATH; PATH alone is not enough.
+                  Environment = "SASL_PATH=${pkgs.cyrus-sasl-xoauth2}/lib/sasl2";
+                  EnvironmentFile = config.sops.secrets."mailarchive/${name}".path;
+                  ExecStart = "${pkgs.isync}/bin/mbsync -c /etc/mailarchive/mbsync-${name}.rc -a";
+                  # ExecStartPost only runs on ExecStart success — heartbeat
+                  # therefore reflects last successful sync.
+                  ExecStartPost = "${pkgs.coreutils}/bin/touch /var/lib/mailarchive/${name}.heartbeat";
+                  Nice = 10;
+                };
+              }
+          )
+          cfg.accounts)
+        // lib.optionalAttrs (cfg.accounts != {}) {
+          # Long-running heartbeat HTTP server, polled by Uptime Kuma.
+          mailarchive-health = {
+            description = "Mail archival heartbeat HTTP server";
+            wantedBy = ["multi-user.target"];
+            after = ["network-online.target"];
+            wants = ["network-online.target"];
+            environment = {
+              BIND_HOST = "127.0.0.1";
+              BIND_PORT = toString cfg.healthPort;
+              HEARTBEAT_DIR = "/var/lib/mailarchive";
+              STALE_THRESHOLD_SEC = toString cfg.staleThresholdSec;
+              ACCOUNTS = lib.concatStringsSep "," (lib.attrNames cfg.accounts);
+            };
+            serviceConfig = {
+              Type = "simple";
+              User = "mailarchive";
+              Group = "mailarchive";
+              ExecStart = "${healthServer}/bin/mailarchive-health";
+              Restart = "on-failure";
+              RestartSec = 5;
+            };
+          };
+        };
+
+      timers =
+        lib.mapAttrs' (
+          name: acct:
+            lib.nameValuePair "mailarchive-${name}" {
+              description = "Mail archival timer (${name})";
+              wantedBy = ["timers.target"];
+              timerConfig = {
+                OnBootSec = "2min";
+                OnUnitActiveSec = "${toString acct.syncIntervalSec}s";
+                AccuracySec = "10s";
+                Unit = "mailarchive-${name}.service";
+              };
+            }
+        )
+        cfg.accounts;
+    };
+
+    homelab = {
+      # Per-account Uptime Kuma monitors. Monitor JSON shape is
+      # {"healthy": true|false, ...}; with the server-side threshold, a stale
+      # fetcher flips healthy→false in ~10 min, then Kuma's
+      # interval=60s × maxretries=10 adds another ~10 min before paging Gotify.
+      monitoring.monitors =
+        lib.mapAttrsToList (name: _: {
+          name = "Mailarchive: ${name}";
+          type = "json-query";
+          url = "http://localhost:${toString cfg.healthPort}/health/${name}";
+          jsonPath = "$.healthy";
+          expectedValue = "true";
+        })
+        cfg.accounts;
+
+      # NFS watchdog — restart the per-account fetcher if its data path
+      # under /mnt/data goes stale. The watchdog stat-checks every 5 min;
+      # mbsync's incremental sync semantics tolerate the gap.
+      nfsWatchdog =
+        lib.mapAttrs' (
+          name: _:
+            lib.nameValuePair "mailarchive-${name}" {
+              path = "${cfg.dataDir}/${name}";
+            }
+        )
+        cfg.accounts;
+    };
+  };
+}

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -262,6 +262,11 @@
   vmTools = import ../vms/package.nix {inherit pkgs;};
 
   proxmoxTemplate = (pkgs.nixos [../vms/template/configuration.nix]).config.system.build.VMA;
+
+  # Mailarchive OAuth2 helper — exposed as a flake app so the bootstrap
+  # device-code flow can be run from any clone before the module is enabled
+  # on doc2 (chicken-and-egg fix). See docs/wiki/services/mailarchive.md.
+  oauth2Helper = import ./pkgs/oauth2-helper.nix {inherit pkgs;};
 in {
   # Make `nix fmt` use Alejandra across the whole repo (defaults to --write).
   formatter = fmtNix;
@@ -279,6 +284,7 @@ in {
     tofu-output = tofuOutput;
     tofu-show = tofuShow;
     proxmox-template = proxmoxTemplate;
+    oauth2-helper = oauth2Helper;
   };
 
   apps = {
@@ -337,6 +343,11 @@ in {
       type = "app";
       program = "${lib.getExe tofuShow}";
       meta.description = "Show generated Terranix/OpenTofu config";
+    };
+    oauth2-helper = {
+      type = "app";
+      program = "${lib.getExe oauth2Helper}";
+      meta.description = "OAuth2 device-code bootstrap + refresh helper for mbsync";
     };
   };
 

--- a/nix/pkgs/oauth2-helper.nix
+++ b/nix/pkgs/oauth2-helper.nix
@@ -1,0 +1,224 @@
+# OAuth2 helper for mbsync — refresh tokens at sync time, plus a one-time
+# device-code bootstrap subcommand.
+#
+# Used by:
+# - modules/nixos/services/mailarchive.nix  (mbsync PassCmd → `oauth2-helper refresh`)
+# - nix/devshell.nix                         (apps.oauth2-helper for `nix run`)
+#
+# Runbook: docs/wiki/services/mailarchive.md
+{pkgs}:
+pkgs.writers.writePython3Bin "oauth2-helper" {
+  flakeIgnore = ["E501" "E402"];
+} ''
+  """OAuth2 helper for mbsync — refresh + bootstrap for Gmail and O365."""
+
+  import argparse
+  import json
+  import os
+  import sys
+  import time
+  import urllib.error
+  import urllib.parse
+  import urllib.request
+
+  THUNDERBIRD_O365_CLIENT_ID = "9e5f94bc-e8a4-4e73-b8be-63364c29d753"
+  O365_SCOPE = "offline_access https://outlook.office.com/IMAP.AccessAsUser.All"
+  GMAIL_SCOPE = "https://mail.google.com/"
+
+
+  def o365_endpoints(tenant):
+      base = f"https://login.microsoftonline.com/{tenant}/oauth2/v2.0"
+      return base + "/devicecode", base + "/token"
+
+
+  def gmail_endpoints():
+      return ("https://oauth2.googleapis.com/device/code",
+              "https://oauth2.googleapis.com/token")
+
+
+  def http_post(url, params, timeout=30):
+      body = urllib.parse.urlencode(params).encode()
+      req = urllib.request.Request(url, data=body, method="POST")
+      req.add_header("Content-Type", "application/x-www-form-urlencoded")
+      with urllib.request.urlopen(req, timeout=timeout) as r:
+          return json.loads(r.read())
+
+
+  def die(msg, code=1):
+      sys.stderr.write(f"oauth2-helper: {msg}\n")
+      raise SystemExit(code)
+
+
+  def cmd_refresh(args):
+      provider = os.environ.get("OAUTH_PROVIDER") or args.provider
+      if provider not in ("o365", "gmail"):
+          die("provider must be set via --provider or OAUTH_PROVIDER (o365|gmail)")
+      refresh = os.environ.get("OAUTH_REFRESH_TOKEN")
+      if not refresh:
+          die("OAUTH_REFRESH_TOKEN not set")
+      client_id = os.environ.get("OAUTH_CLIENT_ID")
+      if not client_id:
+          if provider == "o365":
+              client_id = THUNDERBIRD_O365_CLIENT_ID
+          else:
+              die("OAUTH_CLIENT_ID not set (required for gmail)")
+      client_secret = os.environ.get("OAUTH_CLIENT_SECRET")
+      tenant = os.environ.get("OAUTH_TENANT") or "common"
+
+      if provider == "o365":
+          _, token_url = o365_endpoints(tenant)
+          params = {
+              "client_id": client_id,
+              "grant_type": "refresh_token",
+              "refresh_token": refresh,
+              "scope": O365_SCOPE,
+          }
+      else:  # gmail
+          if not client_secret:
+              die("OAUTH_CLIENT_SECRET not set (required for gmail)")
+          _, token_url = gmail_endpoints()
+          params = {
+              "client_id": client_id,
+              "client_secret": client_secret,
+              "grant_type": "refresh_token",
+              "refresh_token": refresh,
+          }
+
+      try:
+          result = http_post(token_url, params)
+      except urllib.error.HTTPError as e:
+          body = e.read().decode("utf-8", errors="replace")
+          die(f"HTTP {e.code} from token endpoint: {body}")
+      except Exception as e:
+          die(f"refresh failed: {e}")
+
+      access = result.get("access_token")
+      if not access:
+          die(f"no access_token in response: {json.dumps(result)}")
+      print(access)
+
+
+  def cmd_bootstrap(args):
+      provider = args.provider
+      user = args.user
+
+      if provider == "o365":
+          client_id = args.client_id or THUNDERBIRD_O365_CLIENT_ID
+          client_secret = None
+          tenant = args.tenant or "common"
+          device_url, token_url = o365_endpoints(tenant)
+          scope = O365_SCOPE
+      else:  # gmail
+          if not args.client_id or not args.client_secret:
+              die("gmail bootstrap requires --client-id and --client-secret")
+          client_id = args.client_id
+          client_secret = args.client_secret
+          tenant = None
+          device_url, token_url = gmail_endpoints()
+          scope = GMAIL_SCOPE
+
+      dc_params = {"client_id": client_id, "scope": scope}
+      if provider == "o365":
+          dc_params["login_hint"] = user
+
+      try:
+          dc = http_post(device_url, dc_params)
+      except urllib.error.HTTPError as e:
+          body = e.read().decode("utf-8", errors="replace")
+          die(f"device-code request failed: HTTP {e.code}: {body}")
+      except Exception as e:
+          die(f"device-code request failed: {e}")
+
+      user_code = dc.get("user_code")
+      verify_uri = dc.get("verification_uri") or dc.get("verification_url")
+      device_code = dc.get("device_code")
+      interval = int(dc.get("interval", 5))
+      expires_in = int(dc.get("expires_in", 900))
+
+      sys.stderr.write(
+          f"\n  Sign in at: {verify_uri}\n"
+          f"  Code:       {user_code}\n"
+          f"  Account:    {user}\n\n"
+          f"Polling every {interval}s; code expires in {expires_in}s.\n"
+      )
+
+      poll_params = {
+          "client_id": client_id,
+          "device_code": device_code,
+          "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+      }
+      if client_secret:
+          poll_params["client_secret"] = client_secret
+
+      deadline = time.time() + expires_in
+      while time.time() < deadline:
+          time.sleep(interval)
+          try:
+              r = http_post(token_url, poll_params)
+          except urllib.error.HTTPError as e:
+              try:
+                  body = json.loads(e.read())
+              except Exception:
+                  body = {}
+              err = body.get("error", "")
+              if err == "authorization_pending":
+                  continue
+              if err == "slow_down":
+                  interval += 5
+                  continue
+              die(f"token endpoint error: {body}")
+          except Exception as e:
+              die(f"poll failed: {e}")
+
+          if "access_token" not in r:
+              die(f"unexpected response: {json.dumps(r)}")
+          refresh = r.get("refresh_token")
+          if not refresh:
+              die("token endpoint returned no refresh_token (offline_access scope missing?)")
+
+          # paste-ready dotenv block on stdout
+          print(f"OAUTH_PROVIDER={provider}")
+          print(f"OAUTH_CLIENT_ID={client_id}")
+          if client_secret:
+              print(f"OAUTH_CLIENT_SECRET={client_secret}")
+          if tenant and tenant != "common":
+              print(f"OAUTH_TENANT={tenant}")
+          print(f"OAUTH_REFRESH_TOKEN={refresh}")
+          sys.stderr.write(
+              "\nDone. Paste the block above into:\n"
+              "  secrets/hosts/<host>/mailarchive-<account>.env\n"
+              "and re-encrypt with `sops -e -i <path>`.\n"
+          )
+          return
+
+      die("device code expired before sign-in completed")
+
+
+  def main():
+      p = argparse.ArgumentParser(description="OAuth2 helper for mbsync (Gmail / O365)")
+      sub = p.add_subparsers(dest="cmd", required=True)
+
+      pr = sub.add_parser("refresh", help="Print a fresh access token (used by mbsync PassCmd)")
+      pr.add_argument("--provider", choices=["gmail", "o365"],
+                      help="Provider (defaults to OAUTH_PROVIDER env)")
+
+      pb = sub.add_parser("bootstrap", help="One-time interactive device-code flow")
+      pb.add_argument("--provider", choices=["gmail", "o365"], required=True)
+      pb.add_argument("--user", required=True, help="Email address (login_hint for o365)")
+      pb.add_argument("--client-id", default=None,
+                      help="OAuth client ID (defaults to Thunderbird's id for o365)")
+      pb.add_argument("--client-secret", default=None,
+                      help="OAuth client secret (required for gmail)")
+      pb.add_argument("--tenant", default=None,
+                      help="O365 tenant (default: common)")
+
+      args = p.parse_args()
+      if args.cmd == "refresh":
+          cmd_refresh(args)
+      elif args.cmd == "bootstrap":
+          cmd_bootstrap(args)
+
+
+  if __name__ == "__main__":
+      main()
+''

--- a/tools/mailarchive-migrate/README.md
+++ b/tools/mailarchive-migrate/README.md
@@ -1,0 +1,102 @@
+# mailarchive-migrate
+
+One-shot migration utility: MailStore Home archive → nested Maildir tree.
+
+**Plan reference:** [docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan.md](../../docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan.md) (U7)
+**Module:** [modules/nixos/services/mailarchive.nix](../../modules/nixos/services/mailarchive.nix)
+**Runbook:** [docs/wiki/services/mailarchive.md](../../docs/wiki/services/mailarchive.md)
+
+The historical MailStore Home archive (~11 GB, mixed Gmail + O365 in one
+proprietary repository) lives entirely outside the new mailarchive
+module's reach until it's exported and reformatted. Stdlib only — no
+pip, no nixpkgs packaging.
+
+## Why a one-shot tool
+
+`maildir-deduplicate` and `mail-deduplicate` (the renamed PyPI package)
+are **not** packaged in nixpkgs. The migration is small, reversible, and
+runs once — a ~150-line stdlib script is the right tool.
+
+## U7a — Export from MailStore Home
+
+Run on the Win10 VM (VMID 102) before retirement:
+
+1. **MailStore Home** → `Export Email`
+2. Format: **File system, EML format**
+3. **Retain folder structure** ✓
+4. Target path: a temp directory reachable from doc2. Recommended:
+   `/mnt/data/Life/Andy/Email/_mailstore-export-staging/` (NFS mount on
+   the Win VM; remove after migration completes).
+5. Wait for the export. Output is one `.eml` per message, folder
+   hierarchy preserved exactly as MailStore had it.
+
+## U7b — Convert EML tree → Maildir
+
+```bash
+# Dry-run first to confirm folder counts
+python3 tools/mailarchive-migrate/eml-to-maildir.py \
+  --src /mnt/data/Life/Andy/Email/_mailstore-export-staging \
+  --dst /mnt/data/Life/Andy/Email/legacy.archive \
+  --dry-run -v
+
+# Then for real
+python3 tools/mailarchive-migrate/eml-to-maildir.py \
+  --src /mnt/data/Life/Andy/Email/_mailstore-export-staging \
+  --dst /mnt/data/Life/Andy/Email/legacy.archive
+```
+
+Output is a **nested** Maildir tree (matching mbsync's `SubFolders
+Verbatim` layout):
+
+```
+legacy.archive/
+├── Cullen Work/
+│   ├── cur/
+│   ├── new/
+│   ├── tmp/
+│   └── INBOX/
+│       ├── cur/
+│       ├── new/
+│       └── tmp/
+└── Personal/
+    └── ...
+```
+
+NOT Maildir++ (flat dot-separated names like
+`legacy.archive/.Cullen Work.INBOX/`) — that would diverge from the live
+trees and break any future merge.
+
+Messages land in `cur/` with the `:2,S` (Seen) flag.
+
+## U7c — Optional dedup against live trees (deferred)
+
+**Default recommendation: leave `legacy.archive/` separate from the
+live `o365/` and `gmail/` trees forever.** No risk of merge corruption.
+
+If you ever want a unified tree, write a small inline Python script
+(~30 lines) that walks both trees, builds a `Message-ID → filepath`
+map, and on collision deletes the older file (typically the legacy
+copy). Run **after** the live trees have populated and stabilised. The
+plan deliberately defers this — see U7c in the plan doc.
+
+## Verification
+
+After U7b completes:
+
+```bash
+# Folder count sanity check
+find /mnt/data/Life/Andy/Email/legacy.archive -type d -name cur | wc -l
+
+# Open the archive in any standard client to spot-check
+mutt -f /mnt/data/Life/Andy/Email/legacy.archive/Cullen\ Work/INBOX
+```
+
+A clean run reports:
+
+```
+INFO done: <N> written, <M> duplicates skipped, <K> corrupt/failed, <F> folders touched
+```
+
+Spot-check 5 representative messages (plain text, HTML,
+with-attachment, multi-recipient, calendar invite) before declaring
+victory.

--- a/tools/mailarchive-migrate/eml-to-maildir.py
+++ b/tools/mailarchive-migrate/eml-to-maildir.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+MailStore EML export -> nested Maildir migration.
+
+Walks a tree of .eml files (preserving MailStore's folder hierarchy) and
+writes a nested Maildir tree where each folder level is a real
+subdirectory containing its own cur/new/tmp triple. Layout matches
+mbsync's `SubFolders Verbatim` mode so the migrated tree is structurally
+compatible with the live `o365/` and `gmail/` trees the mailarchive
+module produces.
+
+Messages land in `cur/` with the `:2,S` (Seen) flag — historical mail is
+treated as already-read so a future merge with live trees doesn't rewrite
+flags upstream (mbsync runs Pull-only anyway, but this is defensive).
+
+Usage:
+    python3 eml-to-maildir.py --src <export-dir> --dst <maildir-root>
+
+See: tools/mailarchive-migrate/README.md
+     docs/wiki/services/mailarchive.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import email.parser
+import hashlib
+import logging
+import os
+import secrets
+import sys
+import time
+from pathlib import Path
+
+log = logging.getLogger("eml-to-maildir")
+
+
+def setup_logging(verbose: bool) -> None:
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+
+
+def ensure_maildir(folder: Path) -> None:
+    for sub in ("cur", "new", "tmp"):
+        (folder / sub).mkdir(parents=True, exist_ok=True)
+
+
+def message_id_for(eml_bytes: bytes) -> str:
+    """Return Message-ID, falling back to a stable SHA-256 prefix."""
+    parser = email.parser.BytesParser()
+    msg = parser.parsebytes(eml_bytes, headersonly=True)
+    mid = msg.get("Message-ID")
+    if mid:
+        return mid.strip().strip("<>").strip()
+    digest = hashlib.sha256(eml_bytes[:4096]).hexdigest()[:32]
+    return f"synthetic-{digest}"
+
+
+def deliver(folder: Path, eml_bytes: bytes) -> Path:
+    """Atomically write eml_bytes into folder/cur/ with :2,S suffix."""
+    ensure_maildir(folder)
+    timestamp = int(time.time())
+    rand = secrets.token_hex(8)
+    base = f"{timestamp}.M{secrets.randbelow(1_000_000):06d}.maildir-migrate.{rand}"
+    tmp_path = folder / "tmp" / base
+    cur_path = folder / "cur" / f"{base}:2,S"
+    with open(tmp_path, "wb") as f:
+        f.write(eml_bytes)
+    os.rename(tmp_path, cur_path)
+    return cur_path
+
+
+def walk_eml(src: Path):
+    """Yield (eml_path, relative_folder_parts) for every .eml under src."""
+    for dirpath, _, files in os.walk(src):
+        rel = Path(dirpath).relative_to(src)
+        rel_parts = [] if rel == Path(".") else list(rel.parts)
+        for f in files:
+            if f.lower().endswith(".eml"):
+                yield Path(dirpath) / f, rel_parts
+
+
+def run(src: Path, dst: Path, dry_run: bool) -> int:
+    if not src.is_dir():
+        log.error("source %s does not exist or is not a directory", src)
+        return 2
+    seen_ids: set[str] = set()
+    folders_seen: set[Path] = set()
+    written = 0
+    skipped_dup = 0
+    skipped_corrupt = 0
+
+    for eml_path, parts in walk_eml(src):
+        try:
+            eml_bytes = eml_path.read_bytes()
+        except OSError as e:
+            log.warning("read failed: %s (%s)", eml_path, e)
+            skipped_corrupt += 1
+            continue
+
+        try:
+            mid = message_id_for(eml_bytes)
+        except Exception as e:
+            log.warning("parse failed: %s (%s)", eml_path, e)
+            skipped_corrupt += 1
+            continue
+
+        if mid in seen_ids:
+            log.debug("dup: %s (mid=%s)", eml_path, mid)
+            skipped_dup += 1
+            continue
+        seen_ids.add(mid)
+
+        folder = dst.joinpath(*parts) if parts else dst
+        folders_seen.add(folder)
+
+        if dry_run:
+            written += 1
+            continue
+
+        try:
+            deliver(folder, eml_bytes)
+        except Exception as e:
+            log.error("deliver failed: %s -> %s (%s)", eml_path, folder, e)
+            skipped_corrupt += 1
+            continue
+        written += 1
+
+    log.info(
+        "done: %d written, %d duplicates skipped, %d corrupt/failed, %d folders touched",
+        written,
+        skipped_dup,
+        skipped_corrupt,
+        len(folders_seen),
+    )
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--src", required=True, type=Path,
+                   help="Root of MailStore EML export tree")
+    p.add_argument("--dst", required=True, type=Path,
+                   help="Maildir root (e.g. /mnt/data/Life/Andy/Email/legacy.archive)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Walk the tree and report stats; do not write")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args()
+    setup_logging(args.verbose)
+    return run(args.src.resolve(), args.dst.resolve(), args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Replaces VM 102 (Win10 + MailStore Home) with a NixOS-native mail fetcher on **doc2**: `mbsync` + `cyrus-sasl-xoauth2` + a small Python OAuth helper, pulling Gmail and work O365 (cullenwines.com.au) into Maildir under `/mnt/data/Life/Andy/Email/<account>/`.

- **Backup-of-record posture**: Sync = Pull, Create = Near, Remove = None, Expunge = None — server-side deletions never propagate to the local archive.
- **Lands U1–U7 + U8 step 1**. Bootstrap, deploy, and VM 102 retirement are user-driven follow-ups documented in the runbook.
- **Ships disabled** on doc2 (`enable = false`) so initial deploys don't break on missing secrets — flip the switch after running `nix run .#oauth2-helper -- bootstrap ...` for both accounts.

## Docs

- Plan: `docs/plans/2026-05-04-001-feat-mailarchive-mailstore-retirement-plan.md`
- Runbook: `docs/wiki/services/mailarchive.md`

## Test plan

- [ ] `nix build .#nixosConfigurations.doc2.config.system.build.toplevel` succeeds with `enable = false`
- [ ] Run `nix run .#oauth2-helper -- bootstrap` for each account (Gmail, cullenwines)
- [ ] Flip `homelab.services.mailarchive.enable = true` on doc2 and deploy
- [ ] First sync completes; Maildir populated under `/mnt/data/Life/Andy/Email/<account>/`
- [ ] Verify server-side deletions are NOT mirrored locally
- [ ] Retire VM 102 once stable