### PR TITLE
feat(skills): handsfree Android voice input for talk-to-me (WIP)

### DIFF
--- a/.claude/skills/talk-to-me/SKILL.md
+++ b/.claude/skills/talk-to-me/SKILL.md
@@ -5,13 +5,18 @@ description: Wire this Claude Code session into the voice.ablz.au SSE bridge so 
 
 # Talk to me — voice mode
 
-Registers this session's transcript with the `claude-voice` service on doc1 so a phone-side TTS subscriber speaks your replies through the user's car Bluetooth.
+Registers this session's transcript with the `claude-voice` service on doc1 so a phone-side TTS subscriber speaks your replies through the user's car Bluetooth. When the current agent is running inside tmux, it also installs a phone-side Termux push-to-talk input script that records audio, transcribes via `whisper.ablz.au`, and pastes the transcript back into this exact tmux pane.
 
 ## What this does
 
 1. Computes the project's transcript directory: `~/.claude/projects/<encoded-cwd>/` where `<encoded-cwd>` is the absolute current working directory with every `/` replaced by `-`.
 2. POSTs that path to `https://voice.ablz.au/register` — a tailnet-only endpoint on doc1.
 3. After registration, the service tails the latest `.jsonl` in that directory and emits every assistant text block as an SSE event. The user's phone (subscribed to `/stream`) speaks each event aloud.
+4. If the agent is running in tmux, installs/refreshes handsfree input config on the phone:
+   - detects the current tmux target
+   - installs `~/.local/bin/agent-voice-inject` on doc1
+   - installs `~/.local/share/agent-voice-input/agent-voice-input-termux.sh` on the phone
+   - writes phone config pointing at the current tmux target and `https://whisper.ablz.au/v1/audio/transcriptions`
 
 ## Critical: how you must talk after this
 
@@ -26,7 +31,7 @@ The user is driving. They can't read a screen, they can only hear you. From the 
 
 ## Register
 
-The user expects this to "just work" — they will not touch the phone. Run **both** of the commands below. The first brings the phone subscriber up cleanly and clears any stale orphans; the second registers this Claude session with the server.
+The user expects this to "just work" — they will not touch the phone. Run **all three** commands below. The first brings the phone subscriber up cleanly and clears any stale orphans; the second registers this Claude session with the server; the third installs the optional handsfree input path when tmux is available.
 
 If the first command fails, stop and surface the error — registering on the server while the phone is silent is worse than failing loudly. Once both succeed, your **next assistant message** is the user's first handshake — make it one short sentence confirming voice mode is live (e.g. *"Voice mode is on, you should hear me through the car now."*).
 
@@ -56,6 +61,28 @@ curl -fsS -X POST https://voice.ablz.au/register \
   -H 'Content-Type: application/json' \
   -d "{\"project\":\"$project\"}"
 ```
+
+```bash
+.claude/skills/talk-to-me/scripts/agent-voice-setup-input.sh || true
+```
+
+If the third command warns about missing tmux or microphone permission, do **not** treat that as output voice-mode failure. Briefly say whether voice input is live or what one-time setup is missing. If it prints a target like `input target: 3:0.0`, input is configured for that pane.
+
+## Handsfree input
+
+After input setup succeeds, the phone-side command is:
+
+```bash
+~/.local/share/agent-voice-input/agent-voice-input-termux.sh
+```
+
+Bind that command from Tasker, AutoVoice, MacroDroid, Automate, Termux:Widget, or any Android automation that can run a Termux command. The script is a toggle:
+
+1. First run starts a bounded microphone recording.
+2. Second run stops recording, POSTs the audio to `whisper.ablz.au`, and SSHes the transcript to doc1.
+3. doc1 pastes the transcript into the tmux target detected during registration and presses Enter.
+
+For bench testing, run the script manually from Termux before wiring steering-wheel or earbud buttons. Termux:API must have Android microphone permission or `termux-microphone-record` will fail with a `RECORD_AUDIO` permission message.
 
 ## Unregister
 

--- a/.claude/skills/talk-to-me/scripts/agent-voice-detect-tmux.sh
+++ b/.claude/skills/talk-to-me/scripts/agent-voice-detect-tmux.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: agent-voice-detect-tmux.sh [--shell|--plain]
+
+Detect the tmux pane that owns the current agent process.
+
+  --shell  emit shell assignments for setup scripts
+  --plain  emit a short human-readable summary (default)
+EOF
+}
+
+mode=plain
+case "${1:-}" in
+  --shell) mode=shell ;;
+  --plain | "") mode=plain ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "unknown argument: $1" >&2
+    usage >&2
+    exit 64
+    ;;
+esac
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "tmux is not installed or not on PATH" >&2
+  exit 127
+fi
+
+if [ -z "${TMUX:-}" ]; then
+  echo "this shell is not inside tmux; handsfree input needs an active tmux pane" >&2
+  echo "candidate panes:" >&2
+  tmux list-panes -a -F '  #{session_name}:#{window_index}.#{pane_index} #{pane_tty} #{pane_current_command} #{pane_title}' 2>/dev/null >&2 || true
+  exit 2
+fi
+
+target=$(tmux display-message -p '#{session_name}:#{window_index}.#{pane_index}')
+tty=$(tmux display-message -p '#{pane_tty}')
+command=$(tmux display-message -p '#{pane_current_command}')
+title=$(tmux display-message -p '#{pane_title}')
+
+case "$mode" in
+  shell)
+    printf 'AGENT_VOICE_TMUX_TARGET=%q\n' "$target"
+    printf 'AGENT_VOICE_TMUX_TTY=%q\n' "$tty"
+    printf 'AGENT_VOICE_TMUX_COMMAND=%q\n' "$command"
+    printf 'AGENT_VOICE_TMUX_TITLE=%q\n' "$title"
+    ;;
+  plain)
+    printf 'target=%s tty=%s command=%s title=%s\n' "$target" "$tty" "$command" "$title"
+    ;;
+esac

--- a/.claude/skills/talk-to-me/scripts/agent-voice-inject.sh
+++ b/.claude/skills/talk-to-me/scripts/agent-voice-inject.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: agent-voice-inject.sh [--no-enter] <tmux-target>
+
+Reads transcript text from stdin, pastes it literally into <tmux-target>,
+and presses Enter unless --no-enter is supplied.
+EOF
+}
+
+send_enter=1
+case "${1:-}" in
+  --no-enter)
+    send_enter=0
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+esac
+
+target="${1:-}"
+if [ -z "$target" ]; then
+  usage >&2
+  exit 64
+fi
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "tmux is not installed or not on PATH" >&2
+  exit 127
+fi
+
+if [[ ! "$target" =~ ^[A-Za-z0-9_.-]+:[0-9]+[.][0-9]+$ ]]; then
+  echo "refusing suspicious tmux target: $target" >&2
+  exit 64
+fi
+
+if ! tmux list-panes -t "$target" >/dev/null 2>&1; then
+  echo "tmux target does not exist: $target" >&2
+  exit 66
+fi
+
+text=$(
+  tr '\r\n\t' '   ' |
+    sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//'
+)
+
+if [ -z "$text" ]; then
+  echo "empty transcript; not submitting" >&2
+  exit 65
+fi
+
+buffer="agent-voice-input-$$"
+printf '%s' "$text" | tmux load-buffer -b "$buffer" -
+tmux paste-buffer -d -b "$buffer" -t "$target"
+
+if [ "$send_enter" -eq 1 ]; then
+  tmux send-keys -t "$target" Enter
+fi
+
+printf 'submitted %d characters to %s\n' "${#text}" "$target" >&2

--- a/.claude/skills/talk-to-me/scripts/agent-voice-input-termux.sh
+++ b/.claude/skills/talk-to-me/scripts/agent-voice-input-termux.sh
@@ -1,0 +1,160 @@
+#!/data/data/com.termux/files/usr/bin/sh
+set -eu
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/agent-voice-input"
+CONFIG_FILE="$CONFIG_DIR/config"
+STATE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/agent-voice-input"
+LOCK_DIR="$STATE_DIR/lock"
+STATE_FILE="$STATE_DIR/current-recording"
+LAST_TRANSCRIPT="$STATE_DIR/last-transcript.txt"
+
+if [ ! -r "$CONFIG_FILE" ]; then
+  echo "missing config: $CONFIG_FILE" >&2
+  exit 78
+fi
+
+# shellcheck disable=SC1090
+. "$CONFIG_FILE"
+
+: "${DOC1_SSH:=doc1}"
+: "${TMUX_TARGET:?missing TMUX_TARGET in $CONFIG_FILE}"
+: "${REMOTE_INJECT:=~/.local/bin/agent-voice-inject}"
+: "${WHISPER_URL:=https://whisper.ablz.au/v1/audio/transcriptions}"
+: "${WHISPER_MODEL:=large}"
+: "${MAX_SECONDS:=45}"
+: "${AUDIO_ENCODER:=aac}"
+: "${AUDIO_EXT:=m4a}"
+: "${AUDIO_RATE:=16000}"
+: "${AUDIO_CHANNELS:=1}"
+
+mkdir -p "$STATE_DIR"
+
+cleanup_lock() {
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+}
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  echo "agent voice input is already running" >&2
+  exit 75
+fi
+trap cleanup_lock EXIT INT TERM
+
+have() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+notify() {
+  msg="$1"
+  echo "$msg" >&2
+  if have termux-vibrate; then
+    termux-vibrate -d 120 >/dev/null 2>&1 || true
+  fi
+  if have termux-notification; then
+    termux-notification --id agent-voice-input --title "Agent voice" --content "$msg" >/dev/null 2>&1 || true
+  fi
+}
+
+need() {
+  if ! have "$1"; then
+    notify "Missing command: $1"
+    exit 127
+  fi
+}
+
+need termux-microphone-record
+need curl
+need jq
+need ssh
+
+start_recording() {
+  ts=$(date +%Y%m%d-%H%M%S)
+  audio="$STATE_DIR/recording-$ts.$AUDIO_EXT"
+  err="$STATE_DIR/start-error.txt"
+
+  if ! termux-microphone-record \
+    -f "$audio" \
+    -l "$MAX_SECONDS" \
+    -e "$AUDIO_ENCODER" \
+    -r "$AUDIO_RATE" \
+    -c "$AUDIO_CHANNELS" >"$err" 2>&1; then
+    if grep -q 'RECORD_AUDIO' "$err" 2>/dev/null; then
+      notify "Grant Termux:API mic permission"
+    else
+      notify "Could not start recording"
+    fi
+    rm -f "$STATE_FILE"
+    exit 1
+  fi
+
+  if grep -q 'RECORD_AUDIO' "$err" 2>/dev/null; then
+    notify "Grant Termux:API mic permission"
+    rm -f "$STATE_FILE"
+    exit 1
+  fi
+
+  termux-microphone-record -i >"$err" 2>&1 || true
+  if grep -q 'RECORD_AUDIO' "$err" 2>/dev/null; then
+    notify "Grant Termux:API mic permission"
+    termux-microphone-record -q >/dev/null 2>&1 || true
+    rm -f "$STATE_FILE"
+    exit 1
+  fi
+
+  rm -f "$err"
+  printf '%s\n' "$audio" >"$STATE_FILE"
+  notify "Recording"
+}
+
+stop_recording() {
+  audio=$(sed -n '1p' "$STATE_FILE" 2>/dev/null || true)
+  rm -f "$STATE_FILE"
+
+  if [ -z "$audio" ]; then
+    notify "No recording state"
+    exit 1
+  fi
+
+  termux-microphone-record -q >/dev/null 2>&1 || true
+  sleep 1
+
+  if [ ! -s "$audio" ]; then
+    notify "Recording was empty"
+    exit 1
+  fi
+
+  notify "Transcribing"
+  response=$(
+    curl -fsS --max-time 180 \
+      -X POST "$WHISPER_URL" \
+      -F "file=@$audio" \
+      -F "model=$WHISPER_MODEL" \
+      -F "response_format=json"
+  ) || {
+    notify "Whisper failed"
+    exit 1
+  }
+
+  text=$(printf '%s' "$response" | jq -r '.text // empty' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
+  printf '%s\n' "$text" >"$LAST_TRANSCRIPT"
+
+  if [ -z "$text" ]; then
+    notify "No speech detected"
+    exit 65
+  fi
+
+  # Values come from the setup-generated config; expansion must happen on the
+  # phone before ssh builds the remote command.
+  # shellcheck disable=SC2029
+  if ! printf '%s\n' "$text" | ssh "$DOC1_SSH" "$REMOTE_INJECT" "$TMUX_TARGET"; then
+    notify "Injection failed"
+    exit 1
+  fi
+
+  notify "Sent"
+}
+
+if [ -f "$STATE_FILE" ]; then
+  stop_recording
+else
+  start_recording
+fi

--- a/.claude/skills/talk-to-me/scripts/agent-voice-setup-input.sh
+++ b/.claude/skills/talk-to-me/scripts/agent-voice-setup-input.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+phone_ssh="${PHONE_SSH:-phone}"
+doc1_ssh="${DOC1_SSH:-doc1}"
+whisper_url="${WHISPER_URL:-https://whisper.ablz.au/v1/audio/transcriptions}"
+whisper_model="${WHISPER_MODEL:-large}"
+max_seconds="${MAX_SECONDS:-45}"
+remote_share=".local/share/agent-voice-input"
+remote_config=".config/agent-voice-input"
+remote_script="$remote_share/agent-voice-input-termux.sh"
+local_inject="$HOME/.local/bin/agent-voice-inject"
+
+sq() {
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
+eval "$("$script_dir/agent-voice-detect-tmux.sh" --shell)"
+target="$AGENT_VOICE_TMUX_TARGET"
+
+install -Dm755 "$script_dir/agent-voice-inject.sh" "$local_inject"
+
+ssh -o ConnectTimeout=8 "$phone_ssh" "mkdir -p '$remote_share' '$remote_config'"
+scp -q "$script_dir/agent-voice-input-termux.sh" "$phone_ssh:$remote_script"
+ssh -o ConnectTimeout=8 "$phone_ssh" "chmod 700 '$remote_share'; chmod 755 '$remote_script'"
+ssh -o ConnectTimeout=8 "$phone_ssh" '
+  mkdir -p ~/.termux
+  touch ~/.termux/termux.properties
+  if grep -q "^[#[:space:]]*allow-external-apps" ~/.termux/termux.properties; then
+    sed -i "s/^[#[:space:]]*allow-external-apps[[:space:]]*=.*/allow-external-apps = true/" ~/.termux/termux.properties
+  else
+    printf "\nallow-external-apps = true\n" >> ~/.termux/termux.properties
+  fi
+  termux-reload-settings >/dev/null 2>&1 || true
+'
+
+# Client-side expansion is intentional here: this command writes the session
+# specific tmux target and helper paths into a static phone-side config file.
+# shellcheck disable=SC2087
+ssh -o ConnectTimeout=8 "$phone_ssh" "cat > '$remote_config/config'" <<EOF
+DOC1_SSH=$(sq "$doc1_ssh")
+TMUX_TARGET=$(sq "$target")
+REMOTE_INJECT=$(sq "$local_inject")
+WHISPER_URL=$(sq "$whisper_url")
+WHISPER_MODEL=$(sq "$whisper_model")
+MAX_SECONDS=$(sq "$max_seconds")
+AUDIO_ENCODER='aac'
+AUDIO_EXT='m4a'
+AUDIO_RATE='16000'
+AUDIO_CHANNELS='1'
+EOF
+
+missing=$(
+  ssh -o ConnectTimeout=8 "$phone_ssh" '
+    for c in termux-microphone-record curl jq ssh; do
+      command -v "$c" >/dev/null 2>&1 || echo "$c"
+    done
+  '
+)
+
+trigger_packages=$(
+  ssh -o ConnectTimeout=8 "$phone_ssh" '
+    pm list packages 2>/dev/null |
+      grep -Ei "tasker|autovoice|macrodroid|automate|termux.tasker|termux.widget" || true
+  '
+)
+
+echo "input target: $target ($AGENT_VOICE_TMUX_COMMAND on $AGENT_VOICE_TMUX_TTY)"
+echo "phone script: $remote_script"
+echo "local inject helper: $local_inject"
+echo "termux external command bridge: enabled"
+
+if [ -n "$missing" ]; then
+  echo "missing phone commands:" >&2
+  printf '%s\n' "$missing" >&2
+  exit 70
+fi
+
+if [ -n "$trigger_packages" ]; then
+  echo "detected trigger package(s):"
+  printf '%s\n' "$trigger_packages"
+else
+  echo "no Tasker/AutoVoice/MacroDroid/Automate trigger package detected"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ tfplan
 result
 result-*
 .cache/
+tools/agent-voice-trigger-android/.debug.keystore
+tools/agent-voice-trigger-android/.release.keystore
+tools/agent-voice-trigger-android/build/
 ha/esphome/secrets.yaml
 ha/esphome/.esphome/
 

--- a/docs/plans/2026-05-27-001-feat-handsfree-agent-voice-input-plan.md
+++ b/docs/plans/2026-05-27-001-feat-handsfree-agent-voice-input-plan.md
@@ -1,0 +1,278 @@
+---
+title: "feat: Add handsfree voice input to talk-to-me"
+type: feat
+status: active
+date: 2026-05-27
+---
+
+# feat: Add handsfree voice input to talk-to-me
+
+## Summary
+
+Extend the existing `talk-to-me` voice mode so the agent can bootstrap handsfree input as well as output: detect the current tmux pane, install/update a narrow Termux recorder script on the phone, transcribe through the existing Whisper endpoint, and paste the resulting text back into the active agent pane.
+
+---
+
+## Problem Frame
+
+The current voice mode solves assistant output but not user input. The user still has to start and stop Android keyboard dictation and sometimes tap Enter, which is too distracting while driving or running. Because the user already runs agent sessions in tmux to view them from the phone, the input path can use the active tmux pane as the session sink instead of building a custom Android app, terminal emulator, or server-side agent controller.
+
+---
+
+## Requirements
+
+**Session binding**
+
+- R1. The skill must derive and surface the active tmux pane when the agent session is running inside tmux.
+- R2. The setup must fail clearly for input bootstrap when the agent is not running in tmux, while preserving output-only voice mode where useful.
+- R3. The input target must be specific to the current pane, not a broad "latest terminal" or shell-history guess.
+
+**Phone-side capture**
+
+- R4. The phone-side implementation must use existing Termux capabilities for v0, not a custom APK.
+- R5. The phone trigger must behave as a toggle: first activation starts recording, second activation stops, transcribes, and submits.
+- R6. Recording must have a maximum duration so stale or accidental captures cannot run indefinitely.
+- R7. The script must give lightweight status feedback suitable for driving, preferably vibration/notification rather than long spoken prompts.
+
+**Transcription and injection**
+
+- R8. Audio must be sent to the existing tailnet-only Whisper endpoint with the default robust model.
+- R9. Transcribed text must be injected into the exact registered tmux pane and submitted with Enter.
+- R10. Injection must handle apostrophes, quotes, shell metacharacters, and whitespace safely.
+- R11. Empty or failed transcriptions must not submit blank prompts to the agent.
+
+**Skill integration**
+
+- R12. The `talk-to-me` skill must be the operator-facing entry point; it should set up output TTS and input bootstrap in one run when possible.
+- R13. The skill must leave enough diagnostics that the user can tell whether output, input, or both are live.
+- R14. The implementation may include a tiny sideloaded trigger APK only as a thin button-to-Termux bridge; Android Auto remains out of scope.
+
+**Least privilege**
+
+- R15. The v0 design must not add an unauthenticated `/input` HTTP endpoint.
+- R16. The phone's ability to inject input must be bounded to the configured tmux target as much as practical for the spike.
+- R17. Any future broadening of phone access, HTTP input, or Android accessibility permissions must be treated as a separate least-privilege decision.
+
+---
+
+## Scope Boundaries
+
+- Do not build a custom terminal or SSH client.
+- Do not attempt to publish anything to Play Store.
+- Do not attempt to make this a real Android Auto app.
+- Do not require replacing the existing `claude-voice` SSE output bridge.
+- Do not add always-on background microphone capture.
+- Do not assume Tasker, AutoVoice, MacroDroid, or Automate is installed; detect trigger tooling and make the script usable without it for bench testing.
+- Do not require Bluetooth headset media-button interception to call the MVP complete; Android may route those buttons to the active music app.
+
+---
+
+## Key Technical Decisions
+
+- **Use tmux as the input sink:** The user already runs phone-visible agent sessions in tmux, so pane injection is the smallest reliable bridge between phone text and the active agent UI.
+- **Keep v0 on Termux scripts:** Termux already has microphone recording, curl, SSH, vibration, and notification helpers on the phone. A script is faster to validate and easier to change than an APK.
+- **Install helpers from the skill:** The skill can derive the current pane and push session-specific config to the phone, so the user does not need to manually edit hostnames, pane ids, or Whisper settings.
+- **Inject via buffer/paste, not shell-quoted keystrokes:** Speech text can contain quotes and shell metacharacters. The server-side helper should read transcript text on stdin, load it into a tmux buffer, paste it into the pane, then send Enter.
+- **Use SSH for v0 instead of HTTP input:** Existing phone-to-doc1 SSH avoids introducing a new authenticated web endpoint. If this proves useful, a tighter forced-command SSH key or tokened local input endpoint can be planned separately.
+- **Treat hardware-button binding as a thin trigger layer:** The core recorder/transcribe/inject script should work from manual invocation first. The sideloaded trigger app, Tasker/AutoVoice/media-button binding, or a dedicated BLE button is then only a way to call that same script.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart LR
+    skill[talk-to-me skill] --> tmux[derive current tmux pane]
+    skill --> phone[install phone config and script]
+    phone --> rec[Termux microphone toggle]
+    rec --> whisper[whisper.ablz.au]
+    whisper --> phone
+    phone --> ssh[ssh doc1]
+    ssh --> inject[agent-voice-inject helper]
+    inject --> tmux
+```
+
+The setup is session-oriented. Each time voice mode starts, the skill discovers the current tmux target and writes that target into phone-side config. The phone trigger does not need to discover the agent; it only records, transcribes, and sends text to the registered sink.
+
+---
+
+## Implementation Units
+
+### U1. Add tmux Target Detection to the Voice Skill
+
+**Goal:** Make the active agent pane an explicit runtime artifact that the skill can show and pass to phone-side input setup.
+
+**Requirements:** R1, R2, R3, R12, R13.
+
+**Files:**
+
+- Modify: `.claude/skills/talk-to-me/SKILL.md`
+- Add: `.claude/skills/talk-to-me/scripts/agent-voice-detect-tmux.sh`
+- Test: no dedicated unit test; verify through tmux and non-tmux shell scenarios.
+
+**Approach:**
+
+- Detect whether `$TMUX` is present and `tmux display-message` can resolve `#{session_name}:#{window_index}.#{pane_index}`.
+- Also capture useful diagnostics such as pane tty and current command for human-readable confirmation.
+- If tmux detection fails, keep the current output-mode bootstrap available but clearly mark handsfree input as unavailable.
+- Include a troubleshooting path that lists candidate panes with `tmux list-panes -a` when the current shell is not itself inside tmux.
+
+**Test scenarios:**
+
+- In a tmux-backed agent session, detection returns the current target and command.
+- Outside tmux, the skill does not guess; it reports that input bootstrap requires tmux.
+- With multiple tmux sessions, the skill binds to the current pane rather than the first or most recent pane.
+
+### U2. Add a Narrow Server-Side tmux Injection Helper
+
+**Goal:** Provide one safe command the phone can call over SSH to paste stdin into the registered pane and press Enter.
+
+**Requirements:** R9, R10, R11, R15, R16.
+
+**Files:**
+
+- Add: `.claude/skills/talk-to-me/scripts/agent-voice-inject.sh`
+- Modify: `.claude/skills/talk-to-me/SKILL.md`
+- Test: no dedicated unit test; verify with local tmux panes and text containing shell metacharacters.
+
+**Approach:**
+
+- Accept the target pane as an argument or config value supplied by the skill.
+- Validate that the target matches a conservative tmux target pattern and exists before reading input.
+- Read transcript text from stdin.
+- Reject empty input after trimming whitespace.
+- Load the text into a named tmux buffer, paste that buffer into the target pane, then send Enter.
+- Prefer whitespace normalization for v0 so dictated text becomes a single prompt unless a later command grammar deliberately supports multiline input.
+
+**Test scenarios:**
+
+- Text containing apostrophes, quotes, dollar signs, semicolons, and backticks is pasted as literal text.
+- Empty stdin exits without sending Enter.
+- A missing or invalid pane exits non-zero and does not paste anywhere else.
+- A normal sentence appears in the agent prompt and submits exactly once.
+
+### U3. Add the Phone-Side Termux Toggle Script
+
+**Goal:** Turn a hardware-button or shortcut invocation into record/stop/transcribe/inject behavior.
+
+**Requirements:** R4, R5, R6, R7, R8, R9, R11.
+
+**Files:**
+
+- Add: `.claude/skills/talk-to-me/scripts/agent-voice-input-termux.sh`
+- Modify: `.claude/skills/talk-to-me/SKILL.md`
+- Test: no dedicated unit test; verify on the phone through SSH and manual Termux invocation.
+
+**Approach:**
+
+- Store phone-side state under a narrow Termux-owned directory, for example the current recording path and whether capture is active.
+- On first invocation, start `termux-microphone-record` with a bounded duration and a Whisper-compatible format.
+- On second invocation, stop recording, POST the audio to `https://whisper.ablz.au/v1/audio/transcriptions` with model `large`, extract `.text`, and SSH the text to the injection helper on doc1.
+- Use vibration or notification feedback for "recording started", "sent", and "failed" states.
+- Recover from stale state by checking Termux microphone status or clearing the state file when no recording is active.
+
+**Test scenarios:**
+
+- First invocation starts recording and records the file path in state.
+- Second invocation stops recording, transcribes, and injects the text.
+- If Whisper is unreachable, the script reports failure and does not inject stale text.
+- If the recording limit expires before the second trigger, the next invocation recovers and either submits the completed audio or resets cleanly.
+- If SSH injection fails, the transcript is preserved locally for retry/debugging.
+
+### U4. Teach the Skill to Install and Refresh Phone Config
+
+**Goal:** Let the agent do the mechanical setup each session so the user does not manually edit the phone.
+
+**Requirements:** R12, R13, R16.
+
+**Files:**
+
+- Modify: `.claude/skills/talk-to-me/SKILL.md`
+- Add or modify scripts under: `.claude/skills/talk-to-me/scripts/`
+- Test: no dedicated unit test; verify over SSH to the phone.
+
+**Approach:**
+
+- Keep the existing phone TTS bootstrap unchanged.
+- After tmux detection, push the Termux script and config to the phone with the current target, doc1 SSH alias, Whisper URL, and model.
+- Push or refresh the server-side injection helper on doc1 if it is missing or outdated.
+- Run a dependency check on the phone for `termux-microphone-record`, `curl`, `jq`, `ssh`, and optional feedback commands.
+- Report a short status summary: output subscriber status, input target, phone script path, and missing trigger-app state if relevant.
+
+**Test scenarios:**
+
+- Running the skill twice refreshes scripts/config without duplicating services or stale state.
+- If the phone is offline, output registration fails as it does today and input setup is not falsely reported as live.
+- If a Termux dependency is missing, the skill names the missing command and leaves output mode behavior unchanged.
+- If the tmux target changes between sessions, the phone config updates to the new target.
+
+### U5. Add Trigger Binding Guidance, Tiny APK, and Bench Verification
+
+**Goal:** Make the first usable trigger path clear without locking the design to one unreliable Android media-button route.
+
+**Requirements:** R5, R7, R13, R14.
+
+**Files:**
+
+- Modify: `.claude/skills/talk-to-me/SKILL.md`
+- Modify: `docs/wiki/claude-code/handsfree-android-voice-input.md`
+- Add: `tools/agent-voice-trigger-android/`
+- Test: no dedicated unit test; verify manual invocation and at least one installed trigger path when available.
+
+**Approach:**
+
+- Define a bench test that invokes the Termux script directly over SSH or from Termux before involving hardware buttons.
+- Detect whether likely trigger apps are installed. On the checked phone, no Tasker/AutoVoice/MacroDroid/Automate package was observed, so do not assume one.
+- Document the intended binding as "call the Termux script from a trigger surface"; the core behavior remains independent of the trigger app.
+- Keep the APK intentionally small: app button, foreground media listener, optional accessibility key-filter experiment, and Termux RUN_COMMAND dispatch only.
+- Record that Bluetooth headset media buttons may still be owned by the active music app and are not a reliable MVP success criterion.
+
+**Test scenarios:**
+
+- Manual trigger from Termux works end-to-end before any hardware-button integration.
+- App button trigger works end-to-end through Termux and Whisper.
+- Repeated rapid triggers do not corrupt state or submit duplicate prompts.
+- The skill can tell the user whether a trigger app still needs one-time Android-side setup.
+- Hardware-trigger testing can be done without changing the core script.
+- If headset media-button capture only controls music, document that as an Android routing limitation rather than continuing to tweak the recorder path.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given the agent is running inside tmux, when the user starts `talk-to-me`, then the skill reports the bound tmux target and installs phone-side input config for that target.
+- AE2. Given the user presses the configured phone trigger once, when the Termux script runs, then recording starts and bounded status feedback fires.
+- AE3. Given recording is active, when the user presses the trigger again from Termux or the trigger app button, then recording stops, audio is transcribed by `whisper.ablz.au`, and the transcript is submitted to the active agent pane.
+- AE4. Given Whisper returns empty text, when the stop trigger completes, then no Enter is sent to the agent.
+- AE5. Given the transcript contains shell-sensitive punctuation, when it is injected, then it appears as literal prompt text rather than being interpreted by the shell.
+- AE6. Given the agent is not in tmux, when `talk-to-me` runs, then output voice mode can still start but input setup is explicitly unavailable.
+
+---
+
+## Risks & Dependencies
+
+- **Hardware-button reliability is device-dependent:** Tasker/AutoVoice/media-button capture may vary by car, earbuds, and active media apps. Live testing showed Bluetooth headset play/pause can remain owned by the music app. The core script must stay trigger-agnostic so a different trigger can call it.
+- **Phone SSH authority is broader than ideal:** The v0 path uses existing SSH because it is available and simple. A follow-up hardening pass should consider a forced-command key or tiny authenticated input service if this becomes a daily workflow.
+- **tmux paste behavior depends on the agent TUI:** The implementation should verify bracketed paste behavior with the active agent UI and normalize whitespace if multiline paste creates accidental submissions.
+- **Audio format support should be verified live:** Termux supports several encoders and the Whisper server converts common formats with ffmpeg, but the exact low-latency format should be chosen by phone-side testing.
+
+---
+
+## Operational Notes
+
+- The skill should preserve the current `talk-to-me` contract: when output voice registration succeeds, the next assistant reply should be short and voice-friendly.
+- Input status should be explicit but brief, for example "Voice output is live; input is bound to tmux target 0:0.0."
+- Phone-side transcripts should be kept only long enough for retry/debugging and should be stored under a narrow temp/cache directory.
+- Do not deploy remote NixOS changes for this v0 unless implementation later chooses to modify the NixOS `claude-voice` service. The current plan is skill/script-only.
+
+---
+
+## Sources
+
+- `docs/wiki/claude-code/handsfree-android-voice-input.md`
+- `.claude/skills/talk-to-me/SKILL.md`
+- `modules/nixos/services/claude-voice.nix`
+- `modules/nixos/services/whisper-server.nix`
+- Android media buttons: https://developer.android.com/media/legacy/media-buttons
+- Android `ACTION_VOICE_COMMAND`: https://developer.android.com/reference/android/content/Intent#ACTION_VOICE_COMMAND
+- Android foreground service types: https://developer.android.com/develop/background-work/services/fgs/service-types

--- a/docs/wiki/claude-code/handsfree-android-voice-input.md
+++ b/docs/wiki/claude-code/handsfree-android-voice-input.md
@@ -1,0 +1,183 @@
+# Handsfree Android Voice Input For Agent Sessions
+
+Date researched: 2026-05-27
+Status: feasible as a one-user Termux + sideloaded-app workflow; Bluetooth headset media-button ownership is constrained by Android/media-session routing.
+
+## Problem
+
+The current `talk-to-me` voice mode is output-only:
+
+- `claude-voice` tails the active Claude transcript and sends assistant text to the phone over SSE.
+- The phone speaks replies with Termux TTS.
+- User input still comes from Android keyboard dictation, which requires tapping to start/stop and sometimes tapping Enter.
+
+That interaction is too distracting while driving or running. The desired replacement is a phone-side push-to-talk path triggered by a steering-wheel, earbud, headset, or other physical button.
+
+## Existing Infrastructure
+
+- `whisper.ablz.au` is already an OpenAI-compatible Whisper endpoint, tailnet-only, backed by `modules/nixos/services/whisper-server.nix`.
+- Dictate Keyboard already proves the transcription leg works: phone records audio, posts to `/v1/audio/transcriptions`, and gets text back.
+- `voice.ablz.au` is already a tailnet-only bridge, but today only exposes assistant-output endpoints: `/register`, `/unregister`, `/stream`, `/healthz`.
+
+## Android Findings
+
+Useful official APIs exist:
+
+- `Intent.ACTION_VOICE_COMMAND` can launch an Activity for a voice-command request. Current Android docs explicitly describe Bluetooth headset / LE Audio extras and recommend starting headset voice recognition plus `AudioRecord` with a preferred Bluetooth device when applicable.
+- `MediaSession` can receive Bluetooth/headset/media key events through `onMediaButtonEvent`. This is the likely path for play/pause/next/previous style buttons, including some steering-wheel media controls.
+- `MediaRecorder` or `AudioRecord` can capture short clips with `RECORD_AUDIO`; `VOICE_RECOGNITION` or `VOICE_COMMUNICATION` are the sensible audio sources.
+- Android 14+ foreground services require explicit service types. A microphone foreground service needs `FOREGROUND_SERVICE_MICROPHONE` and `RECORD_AUDIO`, and background mic startup has while-in-use restrictions.
+
+Useful commands exist for sideloading/testing:
+
+- `adb install -r app-debug.apk`
+- `adb shell input keyevent KEYCODE_MEDIA_PLAY_PAUSE`
+- `adb shell input keyevent KEYCODE_HEADSETHOOK`
+- `adb shell am start -a android.intent.action.VOICE_COMMAND <package>/<activity>`
+
+In this repo environment, `adb`, Gradle, JDK, and Android SDK packages are available via nixpkgs even when not globally installed. `adb` was verified with `nix shell --inputs-from . nixpkgs#android-tools -c adb version`.
+
+## Prior Art
+
+- AutoVoice/Tasker, Automate, and MacroDroid all support variants of Bluetooth/media-button voice triggers. This proves the OS path is real, but also shows reliability is device-dependent.
+- Termly takes a different path: a local CLI spawns the coding agent inside a PTY, streams terminal I/O over an end-to-end encrypted WebSocket relay, and the mobile app provides its own UI and microphone button. It does not appear to solve headset/earbud hardware-button capture; its published voice path is "tap the microphone icon in Termly".
+- OpenClaw Assistant is a broad self-hosted Android assistant using `VoiceInteractionService`, STT, TTS, wake word, and Android assistant integration.
+- Prontafon and phone-whisper are closer to dictation workflows: Android records speech, transcribes, and inserts/sends text elsewhere.
+- Flic / dedicated BLE buttons are common in push-to-talk products and avoid many headset/media-button conflicts.
+
+## Android Auto Boundary
+
+Treat Android Auto as audio transport, not as the app platform for v0.
+
+Normal third-party Android Auto apps must fit allowed car categories and safety templates. A coding-agent voice client does not fit cleanly. Owning the steering-wheel voice-assistant button globally is controlled by Android/Google assistant plumbing, not arbitrary apps. Steering-wheel media buttons may still reach a phone `MediaSession`, but this is not guaranteed across cars and head units.
+
+## Feasible V0
+
+Build a tiny sideloaded Android app:
+
+1. Foreground Activity with one large push-to-talk button for setup/testing.
+2. Declare an Activity for `ACTION_VOICE_COMMAND`.
+3. Optional foreground service with active `MediaSession` to capture media buttons.
+4. On trigger: start recording.
+5. On second trigger, silence timeout, or max duration: stop recording.
+6. POST audio to `https://whisper.ablz.au/v1/audio/transcriptions` with `model=large`.
+7. POST transcript to a new input endpoint on the homelab side.
+
+The server-side input endpoint is the remaining design decision. Options:
+
+- Direct agent input bridge: extend `claude-voice` with `/input`, and require the active agent session to be running in a known tmux pane so the service can send text plus Enter. This is simple and private but terminal-specific.
+- Full custom voice client: Android app talks to a backend that runs/controls the agent directly. This is cleaner long term but no longer just a wrapper around the current CLI session.
+- IME/accessibility wrapper: app inserts text into the currently focused phone UI and taps send. This matches the current Dictate workflow but is more fragile and more Android-permission-heavy.
+
+For a one-user APK, the best first spike is the direct input bridge with an explicit registered sink. Do not attempt a Play Store-safe Android Auto app for v0.
+
+## Easier No-APK Spike: Termux + Tasker
+
+After checking the existing phone environment, there is an easier path than building an APK first:
+
+- Termux already has `termux-microphone-record`.
+- Termux already has `curl`, `jq`, and `ssh`.
+- The phone can SSH to `doc1`.
+- `doc1` has `tmux`.
+
+That means the first working prototype can be:
+
+1. Run the active agent session inside a known `tmux` pane on `doc1`.
+2. Put a toggle script on the phone.
+3. First trigger starts `termux-microphone-record` to a temp file.
+4. Second trigger stops recording with `termux-microphone-record -q`.
+5. The script POSTs the audio file to `https://whisper.ablz.au/v1/audio/transcriptions`.
+6. The script injects the transcript into the known `tmux` pane with SSH.
+
+Use `tmux load-buffer` + `tmux paste-buffer` rather than shell-quoting the transcript into `tmux send-keys`; speech text can contain quotes, newlines, and shell metacharacters.
+
+Trigger options, in increasing robustness:
+
+- Termux:Widget or a launcher shortcut for bench testing.
+- Tasker `Media Button` or AutoVoice `BT Pressed` to call the Termux script.
+- A dedicated BLE button such as Flic if steering-wheel/headset media-button capture is unreliable.
+- Custom APK only after the no-APK path proves the interaction model.
+
+This keeps Android native development out of the first experiment. It does not require creating a terminal UI or embedding SSH in an app; Termux is just the phone-side script runner.
+
+Security note: phone SSH access to `doc1` should eventually use a restricted key or a small authenticated `/input` endpoint. For a spike, using the existing Termux SSH client is acceptable if the target is a single `tmux` pane and the script is kept narrow.
+
+## Live MVP Result: Termux + Tiny Trigger App
+
+Implemented and tested on 2026-05-27:
+
+- `talk-to-me` can detect the current tmux pane and install phone config.
+- `agent-voice-input-termux.sh` records via `termux-microphone-record`, posts to `whisper.ablz.au`, and SSHes transcript text back to the tmux pane.
+- `agent-voice-inject.sh` pastes text safely through a tmux buffer and presses Enter.
+- A tiny sideloaded app under `tools/agent-voice-trigger-android/` can trigger the Termux script from an in-app button.
+- End-to-end app-button test succeeded: spoken audio was transcribed and injected as a Codex prompt.
+- Version `0.3` of the tiny app adds `ACTION_ASSIST`, `ACTION_VOICE_COMMAND`, and a minimal `VoiceInteractionService` so Android can be tested through the default digital assistant path.
+
+The Bluetooth headset media-button path did not succeed reliably. Pressing headset play/pause continued to start/stop the active music app rather than being consistently routed to the trigger app, even with a foreground service and active `MediaSession`.
+
+This matches the expected Android limitation: media buttons are routed through the current media-session/audio-focus stack and are not a reliable generic push-to-talk input when another media app owns playback.
+
+The app includes an Accessibility key-filtering path as an experiment, but this is a broad Android permission and should not be treated as a clean default. If headset interception remains unreliable, prefer one of:
+
+- a dedicated BLE button that can be bound to the app or a Termux command,
+- an Android automation app with proven device-specific media-button capture,
+- using the app's own large button or a future notification action as the v0 trigger,
+- an Android assistant-button / `ACTION_VOICE_COMMAND` route if the headset exposes an assistant gesture separate from media play/pause.
+
+## Follow-up Research: Ways Around Headset Media Routing
+
+Research after the live test points to these options:
+
+1. Default assistant / voice-command path. Android has a first-class `VoiceInteractionService` role for the current global voice interactor, and the selected service is kept running by the system. Android's `ACTION_VOICE_COMMAND` docs explicitly describe Bluetooth headset and LE Audio extras, and recommend starting headset voice recognition plus `AudioRecord` against the originating Bluetooth device. This is the most promising software-only path if the headset exposes a separate assistant gesture. It means the APK becomes a minimal assistant app whose session starts the Termux recorder.
+2. Headphone assistant gesture. Google's own headphone docs distinguish assistant gestures from media play/pause gestures: press-and-hold or touch-and-hold can start Assistant, while media play/pause remains a separate gesture. This is worth testing before writing more code. If the headset only exposes play/pause, skip this path. If it exposes "assistant", set the custom app as the phone's default digital assistant and test that gesture. Live Samsung Buds testing showed another vendor gate: Galaxy Wearable can list the custom assistant but reject it for Buds pinch-and-hold with "your current digital assistant can't be used with earbuds pinch and hold controls." Treat Buds assistant launch as Samsung/Google/Gemini-specific, not generic Android assistant dispatch.
+3. Accessibility key filtering. Android documents `FLAG_REQUEST_FILTER_KEY_EVENTS` and `onKeyEvent` as a way for an accessibility service to receive key events before apps and consume them. The APK includes this experiment, but Android 13+ restricts accessibility for sideloaded apps, and it is a broad permission. Treat as a last-resort personal hack, not a clean architecture.
+4. Automation apps. Tasker, AutoVoice, Key Mapper, Automate, and MacroDroid all have media-button or hardware-key stories, but community reports repeatedly show Bluetooth headset handling is device- and Android-version-dependent. Key Mapper explicitly lists headsets/headphones and the voice-assistant button as supported trigger classes. MacroDroid documents a media-button trigger, but notes device-specific behavior and long-press/default-assistant conflicts. These tools may beat our custom APK because they have years of compatibility work, but they still cannot guarantee play/pause ownership while a music app has the active media session.
+5. Dedicated BLE/PTT button. PTT products such as Zello document explicit Bluetooth PTT-button pairing, and Flic-style buttons are designed to trigger app actions without pretending to be the media play/pause key. This is the most reliable hardware path if assistant-button routing fails. For this project, the button action should call the existing Termux command or launch the tiny APK trigger activity.
+
+Conclusion: stop treating Bluetooth media play/pause as the target. The current software spike is the minimal default-assistant/`ACTION_VOICE_COMMAND` implementation, because that matches Android's intended route for headset voice gestures, but Samsung Buds gate that route too. Google/Pixel Buds documentation also describes the earbud gesture in terms of Google Assistant or Gemini, not arbitrary third-party assistant services. If the user's hardware cannot produce an assistant/PTT-specific event that reaches our app, use a dedicated BLE button instead. The app-button MVP proves the speech pipeline; the missing piece is a hardware event Android is willing to route to us.
+
+## Google Assistant Workaround
+
+Let Google/Gemini keep ownership of the earbud assistant gesture, then use it to launch the trigger app:
+
+- "Hey Google, open Agent Voice Trigger" should launch the app by name.
+- The APK can be changed so launcher start immediately runs the Termux command, or a separate launcher alias such as "Talk to Codex" can do that while the normal app icon remains a settings screen.
+- Full Google Assistant App Actions / feature shortcuts are probably heavier than needed and may depend on Play-distributed app metadata. For this one-user sideloaded app, "open app" is the lowest-friction Google route.
+
+This is not as good as a button, but it avoids Samsung's Buds control gate.
+
+## Least Privilege Notes
+
+- Keep Whisper and input endpoints tailnet-only.
+- Add a per-session random token to any `/input` endpoint; do not accept unauthenticated text injection from the whole tailnet.
+- Avoid always-on background recording. Start capture only from user-initiated button/assistant/media events.
+- Prefer a short max recording duration and visible foreground notification while recording.
+- Avoid broad Android permissions: start with `RECORD_AUDIO`, `INTERNET`, `BLUETOOTH_CONNECT` only if needed for headset routing, and foreground-service permissions only if a service is used.
+
+## Sources
+
+- Android media buttons: https://developer.android.com/media/legacy/media-buttons
+- Android MediaSession: https://developer.android.com/media/media3/session/control-playback
+- Android ACTION_VOICE_COMMAND: https://developer.android.com/reference/android/content/Intent#ACTION_VOICE_COMMAND
+- Android foreground service types: https://developer.android.com/develop/background-work/services/fgs/service-types
+- Android MediaRecorder: https://developer.android.com/media/platform/mediarecorder
+- Android Accessibility key filtering: https://developer.android.com/reference/android/accessibilityservice/AccessibilityServiceInfo#FLAG_REQUEST_FILTER_KEY_EVENTS
+- Android `VoiceInteractionService`: https://developer.android.com/reference/android/service/voice/VoiceInteractionService
+- Android restricted settings: https://support.google.com/android/answer/12623953
+- Android Automotive Voice Interaction app skeleton: https://source.android.com/docs/automotive/voice/voice_interaction_guide/app_development
+- AOSP VoiceInteractionService sample: https://android.googlesource.com/platform/development/+/HEAD/samples/VoiceInteractionService/
+- Google Assistant on headphones: https://support.google.com/assistant/answer/9027902
+- Google Pixel Buds Assistant/Gemini controls: https://support.google.com/googlepixelbuds/answer/7560032
+- Google Assistant app launch/App Actions docs: https://developer.android.com/develop/devices/assistant/overview
+- Termly CLI architecture: https://github.com/termly-dev/termly-cli/blob/main/docs/ARCHITECTURE.md
+- Termly communication protocol: https://github.com/termly-dev/termly-cli/blob/main/COMMUNICATION_PROTOCOL.md
+- Termly product page: https://termly.dev/
+- Termly Claude Code mobile guide: https://termly.dev/blog/claude-code-mobile-setup-guide
+- Key Mapper: https://play.google.com/store/apps/details?id=io.github.sds100.keymapper
+- Key Mapper keymaps docs: https://keymapper.app/user-guide/keymaps/
+- MacroDroid media-button trigger: https://macrodroidforum.com/wiki/index.php/Trigger%3A_Media_Button_Pressed
+- OpenClaw Assistant: https://github.com/yuga-hashimoto/openclaw-assistant
+- AutoVoice: https://play.google.com/store/apps/details?id=com.joaomgcd.autovoice
+- Prontafon: https://prontafon.com/
+- Zello Bluetooth PTT button pairing: https://support.zello.com/hc/en-us/articles/230745407-Pairing-a-Bluetooth-PTT-Button-Android
+- Flic app control: https://flic.io/business/app-control

--- a/tools/agent-voice-trigger-android/AndroidManifest.xml
+++ b/tools/agent-voice-trigger-android/AndroidManifest.xml
@@ -1,0 +1,76 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="au.ablz.agentvoice"
+    android:versionCode="3"
+    android:versionName="0.3">
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="com.termux.permission.RUN_COMMAND" />
+
+    <queries>
+        <package android:name="com.termux" />
+    </queries>
+
+    <application
+        android:theme="@style/AppTheme"
+        android:label="@string/app_name"
+        android:allowBackup="false"
+        android:usesCleartextTraffic="false">
+        <activity
+            android:name=".TriggerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.ASSIST" />
+                <action android:name="android.intent.action.VOICE_COMMAND" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <service
+            android:name=".TriggerService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
+
+        <service
+            android:name=".AgentVoiceInteractionService"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_VOICE_INTERACTION">
+            <meta-data
+                android:name="android.voice_interaction"
+                android:resource="@xml/agent_voice_interaction_service" />
+            <intent-filter>
+                <action android:name="android.service.voice.VoiceInteractionService" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".AgentVoiceInteractionSessionService"
+            android:exported="true"
+            android:permission="android.permission.BIND_VOICE_INTERACTION" />
+
+        <service
+            android:name=".AgentVoiceAccessibilityService"
+            android:exported="true"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/agent_voice_accessibility_service" />
+        </service>
+
+        <receiver
+            android:name=".MediaButtonReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
+    </application>
+</manifest>

--- a/tools/agent-voice-trigger-android/README.md
+++ b/tools/agent-voice-trigger-android/README.md
@@ -1,0 +1,39 @@
+# Agent Voice Trigger Android
+
+Tiny one-user Android helper for `talk-to-me` handsfree input.
+
+The app asks Termux to run:
+
+```sh
+/data/data/com.termux/files/home/.local/share/agent-voice-input/agent-voice-input-termux.sh
+```
+
+The app does not record audio, hold credentials, talk to Whisper, or SSH
+anywhere. Termux does all of that through the existing script.
+
+Trigger routes:
+
+- in-app "Trigger Now" button, already proven end-to-end
+- `ACTION_ASSIST` / `ACTION_VOICE_COMMAND` activity intent
+- minimal `VoiceInteractionService` so Android may offer the app as a default
+  digital assistant
+- best-effort foreground `MediaSession` and accessibility media-button capture
+
+The headset play/pause route is intentionally treated as best-effort only.
+Android routes that key to the active media session, so it is not a reliable
+push-to-talk control while another app owns playback.
+
+## Required phone setup
+
+- Termux and Termux:API installed.
+- The `talk-to-me` skill has installed the Termux script/config.
+- Termux has `allow-external-apps = true` in `~/.termux/termux.properties`.
+- Android grants this app the Termux `Run commands in Termux environment`
+  permission.
+- For the assistant experiment, set this app under Android Settings -> Apps ->
+  Default apps -> Digital assistant app, if Android lists it.
+
+## Build
+
+Use `./build-apk.sh` with `ANDROID_HOME` or `ANDROID_SDK_ROOT` pointing at a
+minimal Android SDK that contains platform 35 and build-tools 35.

--- a/tools/agent-voice-trigger-android/build-apk.sh
+++ b/tools/agent-voice-trigger-android/build-apk.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+build="$root/build"
+package="au.ablz.agentvoice"
+app_name="agent-voice-trigger"
+
+android_home="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+if [ -z "$android_home" ]; then
+  echo "ANDROID_HOME or ANDROID_SDK_ROOT must point at an Android SDK" >&2
+  exit 64
+fi
+
+platform="${ANDROID_PLATFORM:-35}"
+build_tools="${ANDROID_BUILD_TOOLS:-35.0.0}"
+android_jar="${ANDROID_JAR:-$android_home/platforms/android-$platform/android.jar}"
+bt="$android_home/build-tools/$build_tools"
+
+for path in "$android_jar" "$bt/aapt2" "$bt/d8" "$bt/apksigner"; do
+  if [ ! -e "$path" ]; then
+    echo "missing Android build input: $path" >&2
+    exit 66
+  fi
+done
+
+rm -rf "$build"
+mkdir -p "$build/res" "$build/gen" "$build/classes" "$build/dex" "$build/out"
+
+"$bt/aapt2" compile --dir "$root/res" -o "$build/res/compiled.zip"
+"$bt/aapt2" link \
+  -o "$build/out/unsigned.apk" \
+  -I "$android_jar" \
+  --manifest "$root/AndroidManifest.xml" \
+  --java "$build/gen" \
+  --min-sdk-version 26 \
+  --target-sdk-version "$platform" \
+  "$build/res/compiled.zip"
+
+mapfile -t java_sources < <(find "$root/src" "$build/gen" -name '*.java' | sort)
+javac -encoding UTF-8 -source 8 -target 8 \
+  -bootclasspath "$android_jar" \
+  -d "$build/classes" \
+  "${java_sources[@]}"
+
+mapfile -t class_files < <(find "$build/classes" -name '*.class' | sort)
+"$bt/d8" \
+  --lib "$android_jar" \
+  --min-api 26 \
+  --output "$build/dex" \
+  "${class_files[@]}"
+
+cp "$build/out/unsigned.apk" "$build/out/with-dex.apk"
+(cd "$build/dex" && zip -q "$build/out/with-dex.apk" classes.dex)
+
+keystore="$root/.release.keystore"
+if [ ! -f "$keystore" ]; then
+  keytool -genkeypair \
+    -keystore "$keystore" \
+    -storepass agentvoice \
+    -keypass agentvoice \
+    -alias agentvoice \
+    -keyalg RSA \
+    -keysize 4096 \
+    -validity 10000 \
+    -dname "CN=Agent Voice Trigger,O=ABLZ,C=AU" >/dev/null
+fi
+
+"$bt/apksigner" sign \
+  --ks "$keystore" \
+  --ks-pass pass:agentvoice \
+  --key-pass pass:agentvoice \
+  --ks-key-alias agentvoice \
+  --out "$build/out/$app_name.apk" \
+  "$build/out/with-dex.apk"
+
+"$bt/apksigner" verify "$build/out/$app_name.apk"
+echo "$build/out/$app_name.apk"

--- a/tools/agent-voice-trigger-android/res/values/strings.xml
+++ b/tools/agent-voice-trigger-android/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">Agent Voice Trigger</string>
+    <string name="accessibility_description">Intercept headset media buttons for Agent Voice Trigger.</string>
+</resources>

--- a/tools/agent-voice-trigger-android/res/values/styles.xml
+++ b/tools/agent-voice-trigger-android/res/values/styles.xml
@@ -1,0 +1,7 @@
+<resources>
+    <style name="AppTheme" parent="@android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:fontFamily">sans</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:colorAccent">#006C7A</item>
+    </style>
+</resources>

--- a/tools/agent-voice-trigger-android/res/xml/agent_voice_accessibility_service.xml
+++ b/tools/agent-voice-trigger-android/res/xml/agent_voice_accessibility_service.xml
@@ -1,0 +1,8 @@
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/accessibility_description"
+    android:accessibilityEventTypes="typeAllMask"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagRequestFilterKeyEvents"
+    android:canRequestFilterKeyEvents="true"
+    android:canRetrieveWindowContent="false"
+    android:notificationTimeout="0" />

--- a/tools/agent-voice-trigger-android/res/xml/agent_voice_interaction_service.xml
+++ b/tools/agent-voice-trigger-android/res/xml/agent_voice_interaction_service.xml
@@ -1,0 +1,6 @@
+<voice-interaction-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:sessionService="au.ablz.agentvoice.AgentVoiceInteractionSessionService"
+    android:settingsActivity="au.ablz.agentvoice.TriggerActivity"
+    android:supportsAssist="true"
+    android:supportsLaunchVoiceAssistFromKeyguard="true"
+    android:supportsLocalInteraction="true" />

--- a/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/AgentVoiceAccessibilityService.java
+++ b/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/AgentVoiceAccessibilityService.java
@@ -1,0 +1,34 @@
+package au.ablz.agentvoice;
+
+import android.accessibilityservice.AccessibilityService;
+import android.view.KeyEvent;
+import android.view.accessibility.AccessibilityEvent;
+
+public class AgentVoiceAccessibilityService extends AccessibilityService {
+    @Override
+    public void onAccessibilityEvent(AccessibilityEvent event) {
+    }
+
+    @Override
+    public void onInterrupt() {
+    }
+
+    @Override
+    protected boolean onKeyEvent(KeyEvent event) {
+        if (event == null || event.getAction() != KeyEvent.ACTION_DOWN || event.getRepeatCount() > 0) {
+            return false;
+        }
+
+        int code = event.getKeyCode();
+        if (code == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE
+            || code == KeyEvent.KEYCODE_MEDIA_PLAY
+            || code == KeyEvent.KEYCODE_MEDIA_PAUSE
+            || code == KeyEvent.KEYCODE_HEADSETHOOK
+            || code == KeyEvent.KEYCODE_MEDIA_NEXT
+            || code == KeyEvent.KEYCODE_MEDIA_PREVIOUS) {
+            TermuxCommand.run(this);
+            return true;
+        }
+        return false;
+    }
+}

--- a/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/AgentVoiceInteractionService.java
+++ b/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/AgentVoiceInteractionService.java
@@ -1,0 +1,12 @@
+package au.ablz.agentvoice;
+
+import android.os.Bundle;
+import android.service.voice.VoiceInteractionService;
+import android.service.voice.VoiceInteractionSession;
+
+public class AgentVoiceInteractionService extends VoiceInteractionService {
+    @Override
+    public void onLaunchVoiceAssistFromKeyguard() {
+        showSession(new Bundle(), VoiceInteractionSession.SHOW_WITH_ASSIST);
+    }
+}

--- a/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/AgentVoiceInteractionSession.java
+++ b/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/AgentVoiceInteractionSession.java
@@ -1,0 +1,29 @@
+package au.ablz.agentvoice;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.service.voice.VoiceInteractionSession;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.TextView;
+
+public class AgentVoiceInteractionSession extends VoiceInteractionSession {
+    public AgentVoiceInteractionSession(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void onShow(Bundle args, int showFlags) {
+        super.onShow(args, showFlags);
+        TermuxCommand.run(getContext());
+        finish();
+    }
+
+    @Override
+    public View onCreateContentView() {
+        TextView view = new TextView(getContext());
+        view.setGravity(Gravity.CENTER);
+        view.setText("Agent voice trigger");
+        return view;
+    }
+}

--- a/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/AgentVoiceInteractionSessionService.java
+++ b/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/AgentVoiceInteractionSessionService.java
@@ -1,0 +1,12 @@
+package au.ablz.agentvoice;
+
+import android.os.Bundle;
+import android.service.voice.VoiceInteractionSession;
+import android.service.voice.VoiceInteractionSessionService;
+
+public class AgentVoiceInteractionSessionService extends VoiceInteractionSessionService {
+    @Override
+    public VoiceInteractionSession onNewSession(Bundle args) {
+        return new AgentVoiceInteractionSession(this);
+    }
+}

--- a/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/MediaButtonReceiver.java
+++ b/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/MediaButtonReceiver.java
@@ -1,0 +1,27 @@
+package au.ablz.agentvoice;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.view.KeyEvent;
+
+public class MediaButtonReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent == null || !Intent.ACTION_MEDIA_BUTTON.equals(intent.getAction())) {
+            return;
+        }
+
+        KeyEvent event = intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT);
+        Intent service = new Intent(context, TriggerService.class);
+        service.setAction(TriggerService.ACTION_MEDIA_BUTTON);
+        service.putExtra(TriggerService.EXTRA_KEY_EVENT, event);
+
+        if (Build.VERSION.SDK_INT >= 26) {
+            context.startForegroundService(service);
+        } else {
+            context.startService(service);
+        }
+    }
+}

--- a/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/TermuxCommand.java
+++ b/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/TermuxCommand.java
@@ -1,0 +1,37 @@
+package au.ablz.agentvoice;
+
+import android.content.Context;
+import android.content.Intent;
+import android.widget.Toast;
+
+final class TermuxCommand {
+    private static final String TERMUX_PACKAGE = "com.termux";
+    private static final String TERMUX_RUN_COMMAND_SERVICE = "com.termux.app.RunCommandService";
+    private static final String ACTION_RUN_COMMAND = "com.termux.RUN_COMMAND";
+    private static final String EXTRA_COMMAND_PATH = "com.termux.RUN_COMMAND_PATH";
+    private static final String EXTRA_WORKDIR = "com.termux.RUN_COMMAND_WORKDIR";
+    private static final String EXTRA_BACKGROUND = "com.termux.RUN_COMMAND_BACKGROUND";
+    private static final String EXTRA_COMMAND_LABEL = "com.termux.RUN_COMMAND_LABEL";
+
+    private static final String TERMUX_HOME = "/data/data/com.termux/files/home";
+    private static final String SCRIPT_PATH = TERMUX_HOME + "/.local/share/agent-voice-input/agent-voice-input-termux.sh";
+
+    private TermuxCommand() {
+    }
+
+    static void run(Context context) {
+        Intent intent = new Intent(ACTION_RUN_COMMAND);
+        intent.setClassName(TERMUX_PACKAGE, TERMUX_RUN_COMMAND_SERVICE);
+        intent.putExtra(EXTRA_COMMAND_PATH, SCRIPT_PATH);
+        intent.putExtra(EXTRA_WORKDIR, TERMUX_HOME);
+        intent.putExtra(EXTRA_BACKGROUND, true);
+        intent.putExtra(EXTRA_COMMAND_LABEL, "Agent voice input");
+
+        try {
+            context.startService(intent);
+            Toast.makeText(context, "Agent voice trigger", Toast.LENGTH_SHORT).show();
+        } catch (RuntimeException e) {
+            Toast.makeText(context, "Could not run Termux command", Toast.LENGTH_LONG).show();
+        }
+    }
+}

--- a/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/TriggerActivity.java
+++ b/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/TriggerActivity.java
@@ -1,0 +1,164 @@
+package au.ablz.agentvoice;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+public class TriggerActivity extends Activity {
+    private static final int PERMISSION_REQUEST = 1001;
+    private static final String TERMUX_RUN_COMMAND_PERMISSION = "com.termux.permission.RUN_COMMAND";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        requestNeededPermissions();
+        startTriggerService();
+        maybeTriggerFromAssistIntent(getIntent());
+        setContentView(buildView());
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        maybeTriggerFromAssistIntent(intent);
+    }
+
+    private LinearLayout buildView() {
+        LinearLayout root = new LinearLayout(this);
+        root.setOrientation(LinearLayout.VERTICAL);
+        root.setGravity(Gravity.CENTER_HORIZONTAL);
+        int pad = dp(20);
+        root.setPadding(pad, pad, pad, pad);
+
+        TextView title = new TextView(this);
+        title.setText("Agent Voice Trigger");
+        title.setTextSize(24);
+        title.setGravity(Gravity.CENTER);
+        root.addView(title, new LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        TextView body = new TextView(this);
+        body.setText("Leave this listener running. The app button works now. Headset play/pause is unreliable on Android; use a headset assistant gesture or dedicated button if available.");
+        body.setTextSize(16);
+        body.setPadding(0, dp(16), 0, dp(16));
+        root.addView(body, new LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        Button run = new Button(this);
+        run.setText("Trigger Now");
+        run.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                TermuxCommand.run(TriggerActivity.this);
+            }
+        });
+        root.addView(run, new LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        Button settings = new Button(this);
+        settings.setText("Open App Settings");
+        settings.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                intent.setData(Uri.parse("package:" + getPackageName()));
+                startActivity(intent);
+            }
+        });
+        root.addView(settings, new LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        Button accessibility = new Button(this);
+        accessibility.setText("Open Accessibility Settings");
+        accessibility.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivity(new Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS));
+            }
+        });
+        root.addView(accessibility, new LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        Button assistant = new Button(this);
+        assistant.setText("Open Default Apps");
+        assistant.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivity(new Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS));
+            }
+        });
+        root.addView(assistant, new LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        return root;
+    }
+
+    private void maybeTriggerFromAssistIntent(Intent intent) {
+        if (intent == null) {
+            return;
+        }
+
+        String action = intent.getAction();
+        if (Intent.ACTION_ASSIST.equals(action) || Intent.ACTION_VOICE_COMMAND.equals(action)) {
+            TermuxCommand.run(this);
+        }
+    }
+
+    private void requestNeededPermissions() {
+        if (Build.VERSION.SDK_INT < 23) {
+            return;
+        }
+        if (checkSelfPermission(TERMUX_RUN_COMMAND_PERMISSION) == PackageManager.PERMISSION_GRANTED
+            && (Build.VERSION.SDK_INT < 33 || checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED)) {
+            return;
+        }
+
+        if (Build.VERSION.SDK_INT >= 33) {
+            requestPermissions(new String[] {
+                TERMUX_RUN_COMMAND_PERMISSION,
+                Manifest.permission.POST_NOTIFICATIONS
+            }, PERMISSION_REQUEST);
+        } else {
+            requestPermissions(new String[] {
+                TERMUX_RUN_COMMAND_PERMISSION
+            }, PERMISSION_REQUEST);
+        }
+    }
+
+    private void startTriggerService() {
+        Intent intent = new Intent(this, TriggerService.class);
+        if (Build.VERSION.SDK_INT >= 26) {
+            startForegroundService(intent);
+        } else {
+            startService(intent);
+        }
+    }
+
+    private int dp(int value) {
+        return Math.round(value * getResources().getDisplayMetrics().density);
+    }
+}

--- a/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/TriggerService.java
+++ b/tools/agent-voice-trigger-android/src/au/ablz/agentvoice/TriggerService.java
@@ -1,0 +1,166 @@
+package au.ablz.agentvoice;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Intent;
+import android.media.AudioManager;
+import android.media.session.MediaSession;
+import android.media.session.PlaybackState;
+import android.os.Build;
+import android.os.IBinder;
+import android.view.KeyEvent;
+
+public class TriggerService extends Service {
+    static final String ACTION_MEDIA_BUTTON = "au.ablz.agentvoice.MEDIA_BUTTON";
+    static final String EXTRA_KEY_EVENT = "key_event";
+
+    private static final String CHANNEL_ID = "agent_voice_trigger";
+    private static final int NOTIFICATION_ID = 30;
+
+    private MediaSession mediaSession;
+    private final AudioManager.OnAudioFocusChangeListener audioFocusListener =
+        new AudioManager.OnAudioFocusChangeListener() {
+            @Override
+            public void onAudioFocusChange(int focusChange) {
+            }
+        };
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        createNotificationChannel();
+        startMediaSession();
+        requestMediaButtonFocus();
+        startForeground(NOTIFICATION_ID, buildNotification());
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent != null && ACTION_MEDIA_BUTTON.equals(intent.getAction())) {
+            KeyEvent event = intent.getParcelableExtra(EXTRA_KEY_EVENT);
+            handleKeyEvent(event);
+        }
+        return START_STICKY;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onDestroy() {
+        if (mediaSession != null) {
+            mediaSession.setActive(false);
+            mediaSession.release();
+        }
+        super.onDestroy();
+    }
+
+    private void startMediaSession() {
+        mediaSession = new MediaSession(this, "AgentVoiceTrigger");
+        mediaSession.setFlags(MediaSession.FLAG_HANDLES_MEDIA_BUTTONS | MediaSession.FLAG_HANDLES_TRANSPORT_CONTROLS);
+        mediaSession.setCallback(new MediaSession.Callback() {
+            @Override
+            public boolean onMediaButtonEvent(Intent mediaButtonIntent) {
+                KeyEvent event = mediaButtonIntent.getParcelableExtra(Intent.EXTRA_KEY_EVENT);
+                return handleKeyEvent(event);
+            }
+
+            @Override
+            public void onPlay() {
+                TermuxCommand.run(TriggerService.this);
+            }
+
+            @Override
+            public void onPause() {
+                TermuxCommand.run(TriggerService.this);
+            }
+
+            @Override
+            public void onSkipToNext() {
+                TermuxCommand.run(TriggerService.this);
+            }
+
+            @Override
+            public void onSkipToPrevious() {
+                TermuxCommand.run(TriggerService.this);
+            }
+        });
+        mediaSession.setPlaybackState(new PlaybackState.Builder()
+            .setActions(
+                PlaybackState.ACTION_PLAY
+                    | PlaybackState.ACTION_PAUSE
+                    | PlaybackState.ACTION_PLAY_PAUSE
+                    | PlaybackState.ACTION_SKIP_TO_NEXT
+                    | PlaybackState.ACTION_SKIP_TO_PREVIOUS)
+            .setState(PlaybackState.STATE_PLAYING, 0, 1.0f)
+            .build());
+        mediaSession.setActive(true);
+    }
+
+    private boolean handleKeyEvent(KeyEvent event) {
+        if (event == null || event.getAction() != KeyEvent.ACTION_DOWN || event.getRepeatCount() > 0) {
+            return false;
+        }
+
+        int code = event.getKeyCode();
+        if (code == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE
+            || code == KeyEvent.KEYCODE_MEDIA_PLAY
+            || code == KeyEvent.KEYCODE_MEDIA_PAUSE
+            || code == KeyEvent.KEYCODE_HEADSETHOOK
+            || code == KeyEvent.KEYCODE_MEDIA_NEXT
+            || code == KeyEvent.KEYCODE_MEDIA_PREVIOUS) {
+            TermuxCommand.run(this);
+            return true;
+        }
+        return false;
+    }
+
+    private Notification buildNotification() {
+        Notification.Builder builder = Build.VERSION.SDK_INT >= 26
+            ? new Notification.Builder(this, CHANNEL_ID)
+            : new Notification.Builder(this);
+
+        builder
+            .setSmallIcon(android.R.drawable.ic_btn_speak_now)
+            .setContentTitle("Agent voice trigger")
+            .setContentText("Listening for headset media buttons")
+            .setOngoing(true);
+
+        if (Build.VERSION.SDK_INT >= 21 && mediaSession != null) {
+            builder.setStyle(new Notification.MediaStyle()
+                .setMediaSession(mediaSession.getSessionToken())
+                .setShowActionsInCompactView());
+        }
+
+        return builder.build();
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT < 26) {
+            return;
+        }
+        NotificationChannel channel = new NotificationChannel(
+            CHANNEL_ID,
+            "Agent voice trigger",
+            NotificationManager.IMPORTANCE_LOW
+        );
+        NotificationManager manager = getSystemService(NotificationManager.class);
+        manager.createNotificationChannel(channel);
+    }
+
+    @SuppressWarnings("deprecation")
+    private void requestMediaButtonFocus() {
+        AudioManager manager = (AudioManager) getSystemService(AUDIO_SERVICE);
+        if (manager != null) {
+            manager.requestAudioFocus(
+                audioFocusListener,
+                AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
WIP work-in-progress so it isn't lost — may be picked up later.

- Extends the `talk-to-me` skill with a phone-side push-to-talk input path: Termux records audio, transcribes via `whisper.ablz.au`, and injects the transcript into the active tmux pane on doc1.
- Adds setup/inject/detect scripts under `.claude/skills/talk-to-me/scripts/`.
- Adds an Android trigger app (source only) under `tools/agent-voice-trigger-android/` for binding the toggle to a button/widget.
- Adds a plan doc (`docs/plans/`) and a wiki writeup (`docs/wiki/claude-code/handsfree-android-voice-input.md`).
- `.gitignore` updated to exclude build artefacts and signing keystores.

## Status
Not finished — parked for future pickup. No deploy impact (skill/tooling only, nothing in the NixOS closure).

## Test plan
- [ ] End-to-end: button → record → whisper transcript → tmux paste on doc1
- [ ] Verify Termux mic permission flow
- [ ] APK build via `tools/agent-voice-trigger-android/build-apk.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)