### PR TITLE
Sandbox /mnt for Class-A services + forgejo (#257)

### DIFF
--- a/docs/wiki/nixos-service-modules.md
+++ b/docs/wiki/nixos-service-modules.md
@@ -807,9 +807,44 @@ value. In Nix, the indented-string form `''/path/with\ space''` writes the
 right bytes directly. `\x20` does **not** work — the BindPaths parser takes
 it literally.
 
+#### Default for new doc2 services (#257)
+
+As of the #257 audit, **`TemporaryFileSystem=/mnt` is the default for every new
+doc2 service**, not an opt-in. doc2 has six-plus NFS/virtiofs exports under
+`/mnt`; the default-hardened (or unhardened) unit sees all of them. Pick the
+right shape:
+
+- **No `/mnt` state at all** (HTTP-only helpers, services whose state is in a
+  DB container or `/var/lib`): `serviceConfig.TemporaryFileSystem = "/mnt";`
+  with **no** `BindPaths`. Blank tmpfs, nothing bound back. `TemporaryFileSystem`
+  forces a private mount namespace on its own, so this works even when upstream
+  leaves `PrivateMounts=no`.
+- **Needs one or more `/mnt/*` subdirs**: add `BindPaths = [ ... ]` for exactly
+  those (src==dst when no rename needed; `src:dst` to rename a space-bearing
+  source to a space-free mountpoint).
+
+Two rules that bit us during the audit:
+
+1. **Order the unit after its bind sources.** `BindPaths` is fail-loud, so if a
+   virtiofs/NFS source isn't mounted yet at unit start the unit dies with
+   `226/NAMESPACE` during early boot. Add
+   `unitConfig.RequiresMountsFor = [ <each bound /mnt path> ];` — it resolves to
+   the backing `*.mount` unit and both orders-after and pulls-in. (Old
+   `ReadWritePaths=` hid this by silently skipping the unmounted source; the
+   fail-loud bind exposes it.)
+2. **errorPattern policy.** Add a `Failed at step NAMESPACE` `errorPatterns`
+   entry **only when the unit binds a real `/mnt/*` source** that can disappear
+   (NFS stale, dataset unmounted). A blank-`/mnt`-no-bind unit has nothing to
+   fail on — a tmpfs-only namespace effectively never fails to set up — so skip
+   the pattern there and rely on the HTTP/Kuma monitor (note this in a comment).
+   For units that already have an errorPattern for their main service, append
+   `|Failed at step NAMESPACE` to the existing alternation rather than adding a
+   second entry.
+
 See `docs/wiki/infrastructure/systemd-sandbox-mnt.md` for the failure-mode
-narrative this rule grew out of, and `modules/nixos/services/paperless.nix`
-for the canonical implementation.
+narrative this rule grew out of and the per-service audit findings, and
+`modules/nixos/services/paperless.nix` for the canonical implementation
+(`forgejo.nix` for the two-bind / NFS-dump variant).
 
 ## Checklist
 
@@ -846,8 +881,15 @@ Before submitting a new service module:
 - [ ] No `fileSystems` mountpoint contains literal spaces; use space-free
       service-facing paths via `TemporaryFileSystem=/mnt`+`BindPaths=`
       instead (see Sandbox patterns section)
+- [ ] **doc2 services: `TemporaryFileSystem=/mnt` on every unit** (default, not
+      opt-in — see "Default for new doc2 services"). Blank tmpfs + `BindPaths=`
+      for exactly the `/mnt/*` paths the unit needs (often none)
+- [ ] Every bound `/mnt/*` source has a matching
+      `unitConfig.RequiresMountsFor` entry so the fail-loud bind can't race the
+      mount at boot
 - [ ] For NFS-backed writable paths: use `BindPaths=` not `ReadWritePaths=`
-      (fail-loud vs silent-skip), and add `Failed at step NAMESPACE` to
-      every unit's `errorPatterns` entry
+      (fail-loud vs silent-skip), and add `Failed at step NAMESPACE` to the
+      `errorPatterns` of any unit that binds a real `/mnt/*` source (skip it for
+      blank-`/mnt`-no-bind units — nothing to fail on)
 - [ ] Service enabled in appropriate host config
 - [ ] `nix build .#nixosConfigurations.<host>.config.system.build.toplevel` succeeds

--- a/modules/nixos/services/atuin.nix
+++ b/modules/nixos/services/atuin.nix
@@ -101,7 +101,15 @@ in {
         config.systemd.units."atuin-db-uri.service".unit
         config.sops.secrets."atuin-pgpass".path
       ];
-      serviceConfig.EnvironmentFile = ["/run/atuin-db-uri/db-env"];
+      serviceConfig = {
+        EnvironmentFile = ["/run/atuin-db-uri/db-env"];
+        # Blank /mnt (#257). The atuin server is stateless — all persistent
+        # state lives in the atuin-db nspawn container, not under /mnt — so it
+        # needs nothing bound back. TemporaryFileSystem masks the host's whole
+        # /mnt/* tree (previously ro-visible: every NFS export on doc2).
+        # See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
+        TemporaryFileSystem = "/mnt";
+      };
     };
 
     homelab = {
@@ -125,7 +133,7 @@ in {
         {
           name = "Atuin DB connection failure";
           unit = "atuin.service";
-          pattern = "(?i)password authentication failed for user \"atuin\"|failed to connect to db";
+          pattern = "(?i)password authentication failed for user \"atuin\"|failed to connect to db|Failed at step NAMESPACE";
           severity = "critical";
           summary = "Atuin server cannot reach its DB";
         }

--- a/modules/nixos/services/domain-monitor.nix
+++ b/modules/nixos/services/domain-monitor.nix
@@ -76,6 +76,13 @@ in {
       mode = "0444";
     };
 
+    # Blank /mnt (#257). Gatus probes over the network and reads config from
+    # /etc — it needs nothing under /mnt, so mask the whole tree.
+    # TemporaryFileSystem forces a private mount namespace (upstream leaves
+    # PrivateMounts=no). No bind source → no NAMESPACE errorPattern.
+    # See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
+    systemd.services.gatus.serviceConfig.TemporaryFileSystem = "/mnt";
+
     homelab = {
       localProxy.hosts = [
         {

--- a/modules/nixos/services/forgejo.nix
+++ b/modules/nixos/services/forgejo.nix
@@ -71,10 +71,33 @@ in {
       "d ${dumpDir} 0750 forgejo forgejo - -"
     ];
 
+    # Sandbox /mnt for both forgejo units (#257). Upstream forgejo.service is
+    # hardened but reaches its NFS dump dir via ReadWritePaths, which
+    # silently skips a missing/contested source (the paperless EROFS class).
+    # forgejo-dump.service is wholly unhardened (ProtectSystem=no) and sees
+    # every /mnt/* export RW. Replace both with a blank /mnt + fail-loud
+    # BindPaths binding only the two paths forgejo needs: its virtiofs
+    # stateDir (repos, app.ini, .secrets/) and its NFS dump dir.
+    # RequiresMountsFor orders each unit after the backing mounts so the
+    # fail-loud binds can't race them at boot.
+    # See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
+    systemd.services.forgejo = {
+      unitConfig.RequiresMountsFor = [cfg.dataDir dumpDir];
+      serviceConfig = {
+        TemporaryFileSystem = "/mnt";
+        BindPaths = [cfg.dataDir dumpDir];
+      };
+    };
+
     # Dump only fires when NFS is up — stale handle would crash it otherwise.
     systemd.services.forgejo-dump = {
       after = ["mnt-data.mount"];
       requires = ["mnt-data.mount"];
+      unitConfig.RequiresMountsFor = [cfg.dataDir dumpDir];
+      serviceConfig = {
+        TemporaryFileSystem = "/mnt";
+        BindPaths = [cfg.dataDir dumpDir];
+      };
     };
 
     # Forgejo's built-in Go SSH server on :2222 (separate from sshd on :22).
@@ -96,10 +119,29 @@ in {
         }
       ];
 
-      # See #253 audit. Skipped — important git server but no observed
-      # failure fingerprints in casual operation; outages surface via
-      # the Kuma HTTP monitor above (/api/healthz).
-      monitoring.errorPatterns = [];
+      # See #253 audit. The git server itself has no actionable failure
+      # fingerprint in casual operation (outages surface via the Kuma
+      # /api/healthz monitor above), but #257 added fail-loud BindPaths for
+      # the virtiofs stateDir and NFS dump dir — page if either bind fails.
+      monitoring.errorPatterns = [
+        {
+          name = "Forgejo NFS/namespace failure";
+          unit = "forgejo.service";
+          pattern = "(?i)Failed at step NAMESPACE";
+          severity = "critical";
+          summary = "forgejo cannot bind its state/dump dirs — git server is down";
+          description = "A BindPaths source (/mnt/virtio/forgejo or the NFS dump dir) is missing or stale — check mnt-virtio.mount / mnt-data.mount on doc2.";
+          threshold = 0;
+        }
+        {
+          name = "Forgejo dump namespace failure";
+          unit = "forgejo-dump.service";
+          pattern = "(?i)Failed at step NAMESPACE";
+          severity = "warning";
+          summary = "forgejo nightly dump cannot bind its dirs — backups are not running";
+          threshold = 0;
+        }
+      ];
     };
   };
 }

--- a/modules/nixos/services/forgejo.nix
+++ b/modules/nixos/services/forgejo.nix
@@ -86,6 +86,13 @@ in {
       serviceConfig = {
         TemporaryFileSystem = "/mnt";
         BindPaths = [cfg.dataDir dumpDir];
+        # Drop upstream's ReadWritePaths (custom, repositories, data/lfs,
+        # dump dir — all under our two BindPaths, already rw). Under the
+        # blank /mnt tmpfs those become self-binds, and the `data/lfs` entry
+        # (LFS is disabled, dir absent) can't be skip-if-missing the way it
+        # is in the host namespace → 226/NAMESPACE. BindPaths makes the whole
+        # stateDir + dump dir rw, so this list is pure redundancy now.
+        ReadWritePaths = lib.mkForce [];
       };
     };
 

--- a/modules/nixos/services/overseerr.nix
+++ b/modules/nixos/services/overseerr.nix
@@ -38,15 +38,23 @@ in {
     };
     users.groups.seerr = {};
 
-    # Override DynamicUser: assign the static seerr user and grant write access
-    # to the virtiofs path. ProtectSystem=strict (upstream) blocks writes by
-    # default; ReadWritePaths= exempts our dataDir.
-    systemd.services.seerr.serviceConfig = {
-      DynamicUser = lib.mkForce false;
-      User = "seerr";
-      Group = "seerr";
-      StateDirectory = lib.mkForce "";
-      ReadWritePaths = [cfg.dataDir];
+    # Override DynamicUser: assign the static seerr user.
+    systemd.services.seerr = {
+      # Order after the virtiofs mount and pull it in, so the fail-loud
+      # BindPaths below can't race the mount at boot.
+      unitConfig.RequiresMountsFor = [cfg.dataDir];
+      serviceConfig = {
+        DynamicUser = lib.mkForce false;
+        User = "seerr";
+        Group = "seerr";
+        StateDirectory = lib.mkForce "";
+        # Blank /mnt + bind only our virtiofs config dir (#257). Was: broad ro
+        # view of all /mnt/* plus dataDir rw via ReadWritePaths (silent-skip).
+        # BindPaths is fail-loud, paired with the NAMESPACE errorPattern below.
+        # See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
+        TemporaryFileSystem = "/mnt";
+        BindPaths = [cfg.dataDir];
+      };
     };
 
     # Create data directory on first boot, owned by the static seerr user.
@@ -75,7 +83,20 @@ in {
       # error logs in the 30-day window; real outages flow through
       # the Kuma HTTP monitor above and through the tailscale-share
       # sidecar pattern in tailscale-share.nix.
-      monitoring.errorPatterns = [];
+      #
+      # NAMESPACE entry added for #257: the unit now binds its virtiofs
+      # config dir fail-loud, so a missing/stale source surfaces here.
+      monitoring.errorPatterns = [
+        {
+          name = "Seerr NFS/namespace failure";
+          unit = "seerr.service";
+          pattern = "(?i)Failed at step NAMESPACE";
+          severity = "critical";
+          summary = "seerr cannot bind its virtiofs config dir — request manager is down";
+          description = "BindPaths source /mnt/virtio/overseerr is missing or stale — check mnt-virtio.mount on doc2.";
+          threshold = 0;
+        }
+      ];
     };
   };
 }

--- a/modules/nixos/services/paperless.nix
+++ b/modules/nixos/services/paperless.nix
@@ -172,6 +172,13 @@ in {
       paperless-task-queue = base;
       paperless-consumer = base;
       paperless-web = base;
+
+      # configureTika spins up standalone gotenberg.service + tika.service
+      # (stateless HTTP helpers for Office/email OCR). They inherit doc2's
+      # full /mnt/* tree for no reason — blank it. No bind source → no
+      # NAMESPACE errorPattern (#257).
+      gotenberg.serviceConfig.TemporaryFileSystem = "/mnt";
+      tika.serviceConfig.TemporaryFileSystem = "/mnt";
     };
 
     # Paperless user needs NFS access

--- a/modules/nixos/services/rtrfm-nowplaying/default.nix
+++ b/modules/nixos/services/rtrfm-nowplaying/default.nix
@@ -94,6 +94,12 @@ in {
         # Hardening
         DynamicUser = true;
         NoNewPrivileges = true;
+        # Blank /mnt (#257). State lives in StateDirectory (/var/lib), not
+        # under /mnt, so nothing is bound back — TemporaryFileSystem masks
+        # the host's /mnt/* tree. A bind/namespace failure here already pages
+        # via the OnFailure=rtrfm-nowplaying-notify unit above, so no separate
+        # NAMESPACE errorPattern. See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
+        TemporaryFileSystem = "/mnt";
         ProtectSystem = "strict";
         ProtectHome = true;
         PrivateTmp = true;

--- a/modules/nixos/services/stirlingpdf.nix
+++ b/modules/nixos/services/stirlingpdf.nix
@@ -18,6 +18,14 @@ in {
       };
     };
 
+    # Blank /mnt (#257). Stateless PDF toolkit — no /mnt access needed, so
+    # mask the host's /mnt/* tree entirely. TemporaryFileSystem forces a
+    # private mount namespace on its own (upstream leaves PrivateMounts=no).
+    # No bind source, so no NAMESPACE errorPattern: a tmpfs-only namespace
+    # has nothing to fail on, and liveness is covered by the Kuma monitor.
+    # See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
+    systemd.services.stirling-pdf.serviceConfig.TemporaryFileSystem = "/mnt";
+
     homelab = {
       localProxy.hosts = [
         {

--- a/modules/nixos/services/uptime-kuma.nix
+++ b/modules/nixos/services/uptime-kuma.nix
@@ -33,14 +33,26 @@ in {
     };
     users.groups.uptime-kuma = {};
 
-    # Override upstream service to use static user and custom data dir
-    systemd.services.uptime-kuma.serviceConfig = {
-      DynamicUser = lib.mkForce false;
-      User = "uptime-kuma";
-      Group = "uptime-kuma";
-      WorkingDirectory = lib.mkForce cfg.dataDir;
-      StateDirectory = lib.mkForce "";
-      ReadWritePaths = [cfg.dataDir];
+    # Override upstream service to use static user and custom data dir.
+    systemd.services.uptime-kuma = {
+      # RequiresMountsFor orders the unit after the virtiofs mount and pulls
+      # it in — without it the fail-loud BindPaths below would race the mount
+      # at boot. Resolves to mnt-virtio.mount for a /mnt/virtio/* dataDir.
+      unitConfig.RequiresMountsFor = [cfg.dataDir];
+      serviceConfig = {
+        DynamicUser = lib.mkForce false;
+        User = "uptime-kuma";
+        Group = "uptime-kuma";
+        WorkingDirectory = lib.mkForce cfg.dataDir;
+        StateDirectory = lib.mkForce "";
+        # Blank /mnt + bind only our virtiofs state dir (#257). Previously the
+        # unit saw all of /mnt/* ro and got dataDir rw via ReadWritePaths,
+        # which silently skips a missing/contested source. BindPaths is
+        # fail-loud (status=226/NAMESPACE) — paired with the NAMESPACE
+        # errorPattern below. See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
+        TemporaryFileSystem = "/mnt";
+        BindPaths = [cfg.dataDir];
+      };
     };
 
     homelab = {
@@ -66,7 +78,7 @@ in {
         {
           name = "Uptime Kuma server failure";
           unit = "uptime-kuma.service";
-          pattern = "(?i)FATAL|UnhandledPromiseRejection|database is locked";
+          pattern = "(?i)FATAL|UnhandledPromiseRejection|database is locked|Failed at step NAMESPACE";
           severity = "critical";
           summary = "Uptime Kuma is failing — HTTP monitors will silently stop";
           # Single-shot: a FATAL / UnhandledPromiseRejection takes the


### PR DESCRIPTION
First implementation batch of the #257 doc2 `/mnt` visibility audit.

## What

Applies the paperless `TemporaryFileSystem=/mnt` + `BindPaths=` pattern to narrow each unit's `/mnt` blast radius from "all NFS/virtiofs exports, readable" down to "only what it actually needs".

| Service | Before | After |
|---|---|---|
| atuin | all `/mnt/*` ro | blank `/mnt` (state in DB container) |
| stirling-pdf, gatus, gotenberg, tika, rtrfm | all `/mnt/*` (RW for the unhardened ones) | blank `/mnt` |
| uptime-kuma, seerr | all `/mnt/*` ro + dataDir via `ReadWritePaths` (silent-skip) | blank `/mnt` + fail-loud `BindPaths` of the one virtiofs dir |
| forgejo | hardened, NFS dump dir via silent-skip `ReadWritePaths` | blank `/mnt` + `BindPaths` stateDir + dump dir |
| forgejo-dump | **fully unhardened** (`ProtectSystem=no`, all `/mnt` RW) | blank `/mnt` + `BindPaths` stateDir + dump dir |

## Safety / least-privilege notes

- `BindPaths` is fail-loud (`226/NAMESPACE`) vs `ReadWritePaths`'s silent-skip — this is the property that turns the paperless EROFS incident class into an alert instead of a silent read-only degradation.
- Every bound `/mnt/*` source gets `unitConfig.RequiresMountsFor` so the fail-loud bind can't race its mount during early boot.
- `Failed at step NAMESPACE` added to `errorPatterns` for every unit that binds a real source; deliberately skipped for blank-`/mnt`-no-bind units (nothing to fail on).

## Docs

`docs/wiki/nixos-service-modules.md` — `TemporaryFileSystem=/mnt` is now the documented **default** for new doc2 services, with the mount-ordering and errorPattern-policy learnings folded into the Sandbox patterns section + checklist.

## Deploy notes

Restarts forgejo / forgejo-dump / seerr / uptime-kuma / atuin / stirling-pdf / gatus / gotenberg / tika / rtrfm on doc2. Verified post-deploy that each unit's `/proc/<pid>/mountinfo` shows only its bound paths.

Remaining from #257 (follow-up batches): Class C hardening pass (audiobookshelf, cratedigger×3, discogs, fava, mealie, tautulli, webdav) and immich/Class D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)