### PR TITLE
Sandbox /mnt for Class C services (#257)

### DIFF
--- a/docs/wiki/infrastructure/systemd-sandbox-mnt.md
+++ b/docs/wiki/infrastructure/systemd-sandbox-mnt.md
@@ -104,8 +104,28 @@ Applied the `TemporaryFileSystem=/mnt` pattern to the first batch. All verified 
 1. **Order the unit after its bind sources** — `unitConfig.RequiresMountsFor = [ <each bound /mnt path> ]`. `BindPaths` is fail-loud, so a unit that starts before its virtiofs/NFS mount dies with `226/NAMESPACE` at boot. (Old `ReadWritePaths` masked this by silently skipping the unmounted source.)
 2. **Upstream `ReadWritePaths` under a blank `/mnt` can break the namespace.** forgejo's upstream module lists `${stateDir}/data/lfs` in `ReadWritePaths`; with LFS disabled that dir doesn't exist. In the host namespace `ReadWritePaths` skip-if-missing handles it, but under `TemporaryFileSystem=/mnt` the self-bind can't be skipped → `226/NAMESPACE`. Fix: once `BindPaths` covers the parent dir rw, clear the redundant upstream list with `ReadWritePaths = lib.mkForce [];`. **Check any service whose upstream module sets `ReadWritePaths` under `/mnt` before converting it.**
 
+### Batch 2 — Class C (landed 2026-06-07)
+
+The unhardened set (`ProtectSystem=no`, full `/mnt` **RW**-visible). Done in three sub-batches, each deployed + verified on doc2:
+
+| Service | Shape | Notes |
+|---|---|---|
+| tautulli, gotify-server | `ProtectSystem=strict` + bind 1 virtiofs dataDir | sole path each writes |
+| discogs-api | `ProtectSystem=strict` + blank `/mnt`, no bind | stateless root API (DB over TCP) |
+| discogs-import | blank `/mnt` + bind mirror dir | monthly root oneshot |
+| mealie | blank `/mnt` only | state already binds virtiofs→`/var/lib/mealie` |
+| fava (+ clone/pull) | `ProtectSystem=strict` (fava) + bind virtiofs dataDir | replaced fava's `ReadWritePaths` |
+| webdav | `ProtectSystem=strict` + bind **only** the Zotero Library NFS dir | space-bearing path, escaped |
+| audiobookshelf (+ cache-cleanup) | blank `/mnt` + bind state + declared library dirs | new `libraryDirs` option; real path is `/mnt/data/Media/Books/Audiobooks` |
+| cratedigger ×6 app units | blank `/mnt` + bind state + `/mnt/virtio/Music` + `cfg.downloadDir` | **biggest win** — ran as root seeing `/mnt/backup/pfsense`, `/mnt/appdata`, `/mnt/mum`; validated live (pipeline imported music inside the sandbox with zero errors) |
+
+**Class C learnings:**
+
+- **`ProtectSystem=strict` added only where the writable-path set is known** (single-user services writing one dataDir, or stateless). Skipped for audiobookshelf and the cratedigger app units (large Node/Python apps with unpinned write paths) — there the `/mnt` narrowing alone is the blast-radius win #257 targets.
+- **Verify against the resolved value, not the module default.** cratedigger's `downloadDir` default is `/mnt/data/Media/Temp/slskd`, but doc2 overrides it to `/mnt/virtio/music/slskd` (lowercase, ≠ the capital-M `/mnt/virtio/Music` beets tree). Always read the actual `systemctl show -p BindPaths` and the host override, not the option default, when sanity-checking a namespace.
+- **Audit guesses need confirming.** The audit listed audiobookshelf's library as `/mnt/data/Media/Audiobooks`; the real path (from the ABS sqlite DB) is `/mnt/data/Media/Books/Audiobooks`. Pulled it from `libraryFolders` rather than trusting the issue.
+
 ### Remaining (follow-up batches)
 
-- **Class C** — add `ProtectSystem=strict` + sandbox where upstream omits it: audiobookshelf, cratedigger (×3 units), discogs-api, fava, mealie, tautulli, webdav. Higher breakage risk (may rely on visibility we don't realise) → one at a time with verification.
 - **Class D / immich** — `immich-server` (shares mount namespace with ML subprocess + asset-edit machinery), `immich-machine-learning`, plus free wins on nginx/grafana (`PrivateMounts=yes` + blank `/mnt`).
 - **Class E** (kopia-mum/photos, nspawn `*-db` containers) — legitimately broad / already tight, leave alone.

--- a/modules/nixos/services/audiobookshelf.nix
+++ b/modules/nixos/services/audiobookshelf.nix
@@ -13,6 +13,18 @@ in {
       default = "/var/lib/audiobookshelf";
       description = "Directory where Audiobookshelf stores its data (database, metadata, settings).";
     };
+
+    # #257: ABS library folders are configured in the web UI (stored in its
+    # sqlite DB), but the unit's mount sandbox is static — so the set of NFS
+    # media dirs ABS may read/write has to be declared here too. These are
+    # bound rw (ABS embeds metadata into audio files). If you add a library
+    # folder in the UI under a path NOT listed here, ABS won't be able to see
+    # it (blank /mnt masks everything else). Keep this in sync with the UI.
+    libraryDirs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = ["/mnt/data/Media/Books/Audiobooks"];
+      description = "NFS/media library folders ABS serves; bound into the unit's sandboxed /mnt. Must match the library folders configured in the ABS UI.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -28,20 +40,36 @@ in {
 
     systemd = {
       services = {
-        # Override upstream service to use custom data dir (virtiofs)
-        audiobookshelf.serviceConfig = {
-          WorkingDirectory = lib.mkForce cfg.dataDir;
-          StateDirectory = lib.mkForce "";
+        # Override upstream service to use custom data dir (virtiofs).
+        # #257: ABS shipped no sandboxing and inherited the host's entire
+        # /mnt/* tree RW — including /mnt/backup/pfsense, /mnt/appdata,
+        # /mnt/mum. Blank /mnt and bind back only its virtiofs state dir plus
+        # the declared NFS library folders (rw — ABS embeds metadata into
+        # audio files). RequiresMountsFor orders the fail-loud binds after
+        # their mounts. (ProtectSystem=strict deliberately NOT added here —
+        # the Node app's full set of writable paths isn't pinned down; the
+        # /mnt narrowing is the blast-radius win that #257 targets.)
+        audiobookshelf = {
+          unitConfig.RequiresMountsFor = [cfg.dataDir] ++ cfg.libraryDirs;
+          serviceConfig = {
+            WorkingDirectory = lib.mkForce cfg.dataDir;
+            StateDirectory = lib.mkForce "";
+            TemporaryFileSystem = "/mnt";
+            BindPaths = [cfg.dataDir] ++ cfg.libraryDirs;
+          };
         };
 
         # Weekly cleanup of embed-metadata backups (originals stashed by ABS
         # when the API embed endpoint writes tags into audio files)
         audiobookshelf-cache-cleanup = {
           description = "Purge Audiobookshelf embed-metadata backup cache";
+          unitConfig.RequiresMountsFor = [cfg.dataDir];
           serviceConfig = {
             Type = "oneshot";
             ExecStart = "${lib.getExe' config.systemd.package "rm"} -rf ${cfg.dataDir}/metadata/cache/items";
             User = "audiobookshelf";
+            TemporaryFileSystem = "/mnt";
+            BindPaths = [cfg.dataDir];
           };
         };
       };
@@ -90,8 +118,19 @@ in {
       #   - per-asset [AudioFileScanner] failures on malformed media
       # None of these represent service-broken state — they're per-asset
       # or external-API noise. Real outages flow through the Kuma HTTP
-      # monitor above.
-      monitoring.errorPatterns = [];
+      # monitor above. The one entry is the #257 fail-loud bind of the
+      # virtiofs state dir + NFS library folders.
+      monitoring.errorPatterns = [
+        {
+          name = "Audiobookshelf namespace failure";
+          unit = "audiobookshelf.service";
+          pattern = "(?i)Failed at step NAMESPACE";
+          severity = "critical";
+          summary = "audiobookshelf cannot bind its state/library dirs — server is down";
+          description = "A BindPaths source (virtiofs dataDir or an NFS library folder) is missing or stale — check mnt-virtio.mount / mnt-data.mount on doc2.";
+          threshold = 0;
+        }
+      ];
     };
   };
 }

--- a/modules/nixos/services/beancount.nix
+++ b/modules/nixos/services/beancount.nix
@@ -12,6 +12,14 @@
     [git.ablz.au]:2222 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDD0eMvDPHW7Zqd1HKUhTRwAadPk6Brg98/SDPeAGRF8ptuuOh+1tlQB0f7tmA2mYcMEk557yhZIUT4WEQCRlW09r4CyZYccRgQU6gxvbfehf+/kdcrVt4JocgrZ78t2XD5H81A8ufC4qoJK3LAwmhvDnxPV4mcO2Y7Fn92pdcuhMnFoPLOYPUoznhjy5QAqjOh1fxa0e0SGVoSXUYEr4zXPZsX68bC7k9T84p3aRvY/afdVKupHLcMRNOYTSUuUVLxEHG5aCh3CodQkHUiXIWpFMtALCQL3u7b/kXaM/IV7OtK9bQ8TRafMasK4MHMc2q1x+s49OCQSrAT49u9jji/2rRiHP+yDZxT6WYwqn5tUdOxmBjYfbPnb1pdCqM+iHpndJM/s2LukXBs7Va5EQNCn5LwXTsDwgWN+4k8d0Dbmq8k45l1ACTTqe8XhVwfWR8NckTPMLmxsa/ba7HasL0ll8XarcuKtOgwd3U+XyPamSQtWEr8/thnmvnZLBmwM/kx8uuDTEdqWDdyC9is/NtKt+BhvvX6z76/MvbwwcFAvYIpRg0q2UMnul9R0AlZ13Krm5rmCxCgHJmlIf1yjp8V9ZlKto5bRPvclVV7UCjRltcFwipKSsbOw/mxiAZ7lyimEsD2FMbsCzoUwym+LZQqj6IvHBn+9wt7YeQLjqYYiw==
   '';
   gitSshCommand = "${pkgs.openssh}/bin/ssh -i ${sshKey} -o UserKnownHostsFile=${knownHosts} -o StrictHostKeyChecking=yes -o IdentitiesOnly=yes";
+
+  # #257: all three beancount units (clone, pull, fava) touch only the
+  # virtiofs dataDir (books repo clone + fava cache). Blank /mnt and bind
+  # back just that one path; was full /mnt/* RW-visible and unhardened.
+  mntSandbox = {
+    TemporaryFileSystem = "/mnt";
+    BindPaths = [cfg.dataDir];
+  };
 in {
   options.homelab.services.beancount = {
     enable = lib.mkEnableOption "Beancount + Fava (household accounting journal viewer)";
@@ -66,13 +74,16 @@ in {
 
           path = [pkgs.git pkgs.openssh];
 
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-            User = "fava";
-            Group = "fava";
-            WorkingDirectory = cfg.dataDir;
-          };
+          unitConfig.RequiresMountsFor = [cfg.dataDir];
+          serviceConfig =
+            {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              User = "fava";
+              Group = "fava";
+              WorkingDirectory = cfg.dataDir;
+            }
+            // mntSandbox;
 
           script = ''
             export GIT_SSH_COMMAND='${gitSshCommand}'
@@ -92,12 +103,15 @@ in {
 
           path = [pkgs.git pkgs.openssh];
 
-          serviceConfig = {
-            Type = "oneshot";
-            User = "fava";
-            Group = "fava";
-            WorkingDirectory = cloneDir;
-          };
+          unitConfig.RequiresMountsFor = [cfg.dataDir];
+          serviceConfig =
+            {
+              Type = "oneshot";
+              User = "fava";
+              Group = "fava";
+              WorkingDirectory = cloneDir;
+            }
+            // mntSandbox;
 
           script = ''
             export GIT_SSH_COMMAND='${gitSshCommand}'
@@ -113,15 +127,21 @@ in {
           after = ["beancount-clone.service"];
           requires = ["beancount-clone.service"];
 
-          serviceConfig = {
-            ExecStart = "${pkgs.fava}/bin/fava --host 127.0.0.1 --port ${toString cfg.port} ${cloneDir}/${cfg.journalFile}";
-            User = "fava";
-            Group = "fava";
-            WorkingDirectory = cfg.dataDir;
-            Restart = "on-failure";
-            RestartSec = "10s";
-            ReadWritePaths = [cfg.dataDir];
-          };
+          unitConfig.RequiresMountsFor = [cfg.dataDir];
+          serviceConfig =
+            {
+              ExecStart = "${pkgs.fava}/bin/fava --host 127.0.0.1 --port ${toString cfg.port} ${cloneDir}/${cfg.journalFile}";
+              User = "fava";
+              Group = "fava";
+              WorkingDirectory = cfg.dataDir;
+              Restart = "on-failure";
+              RestartSec = "10s";
+              # #257: read-mostly ledger UI — harden it. ProtectSystem=strict
+              # + blank /mnt bound to the dataDir (replaces the old
+              # ReadWritePaths=[dataDir], which silently-skips a missing source).
+              ProtectSystem = "strict";
+            }
+            // mntSandbox;
         };
       };
 
@@ -152,10 +172,19 @@ in {
         }
       ];
 
-      # See #253 audit. Skipped — Fava is a read-only ledger UI with no
-      # actionable failure log fingerprint; outages surface via the Kuma
-      # HTTP monitor above.
-      monitoring.errorPatterns = [];
+      # See #253 audit. Fava is a read-only ledger UI with no actionable
+      # failure log fingerprint (outages surface via the Kuma HTTP monitor
+      # above) — the only entry is the #257 fail-loud bind of its dataDir.
+      monitoring.errorPatterns = [
+        {
+          name = "Fava namespace failure";
+          unit = "fava.service";
+          pattern = "(?i)Failed at step NAMESPACE";
+          severity = "warning";
+          summary = "fava cannot bind its virtiofs dataDir — ledger UI is down";
+          threshold = 0;
+        }
+      ];
     };
   };
 }

--- a/modules/nixos/services/cratedigger.nix
+++ b/modules/nixos/services/cratedigger.nix
@@ -48,6 +48,26 @@
 
   metadataGateStateDir = "/run/cratedigger-metadata-gate";
   metadataGateHoldDir = "${metadataGateStateDir}/holds";
+
+  # #257: the cratedigger app units run as ROOT and inherited the host's
+  # entire /mnt tree RW — including /mnt/backup/pfsense (the pfSense ZFS
+  # backups), /mnt/appdata, /mnt/mum, /mnt/mirrors. The pipeline's real scope
+  # is three paths: its virtiofs state/backups dir, the shared music tree
+  # (beets library + Incoming + Re-download), and the slskd download staging
+  # on NFS. Blank /mnt and bind back exactly those. This is the single
+  # biggest blast-radius reduction in the #257 audit (root + everything → a
+  # root process confined to its own music pipeline). NOT applied to the
+  # gate/secrets/db-migrate/temp-clean oneshots — they touch only /run, /tmp,
+  # or the DB container over TCP. See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
+  musicBinds = [cfg.dataDir "/mnt/virtio/Music" cfg.downloadDir];
+  musicSandboxUnits = [
+    "cratedigger"
+    "cratedigger-web"
+    "cratedigger-importer"
+    "cratedigger-import-preview-worker"
+    "cratedigger-unfindable"
+    "cratedigger-youtube-ingest"
+  ];
   metadataGateGuardedUnits = [
     "cratedigger.timer"
     "cratedigger.service"
@@ -588,6 +608,16 @@ in {
           after = ["cratedigger-musicbrainz-maintenance-hold.service"];
           requires = ["cratedigger-musicbrainz-maintenance-hold.service"];
         }))
+        # #257 /mnt sandbox — merged into each app unit's serviceConfig
+        # (systemd's submodule merge composes this with the ExecCondition /
+        # EnvironmentFile / UMask blocks above). See musicBinds comment.
+        (lib.genAttrs musicSandboxUnits (_: {
+          unitConfig.RequiresMountsFor = musicBinds;
+          serviceConfig = {
+            TemporaryFileSystem = "/mnt";
+            BindPaths = musicBinds;
+          };
+        }))
       ];
 
       timers = {
@@ -647,10 +677,30 @@ in {
         # Per-thread "crashed" alone is too low-bar (ffmpeg per-file
         # failures). "exiting after N crash(es)" is when the worker
         # actually gives up and the preview pipeline stops.
-        pattern = "(?i)Import preview worker exiting after \\d+ worker thread crash";
+        pattern = "(?i)Import preview worker exiting after \\d+ worker thread crash|Failed at step NAMESPACE";
         severity = "critical";
         summary = "preview worker hit the crash limit and exited";
         # Single-shot: worker logs the give-up line once and exits.
+        threshold = 0;
+      }
+      # #257: NAMESPACE start-failures on the music-touching app units (a
+      # bound /mnt source — virtiofs Music/cratedigger or the slskd NFS
+      # staging — went missing). Distinct from the noisy operational logs
+      # that get web/importer skipped above; the unit won't even start.
+      {
+        name = "Cratedigger web namespace failure";
+        unit = "cratedigger-web.service";
+        pattern = "(?i)Failed at step NAMESPACE";
+        severity = "critical";
+        summary = "cratedigger-web cannot bind its music/state dirs — UI is down";
+        threshold = 0;
+      }
+      {
+        name = "Cratedigger importer namespace failure";
+        unit = "cratedigger-importer.service";
+        pattern = "(?i)Failed at step NAMESPACE";
+        severity = "critical";
+        summary = "cratedigger-importer cannot bind its music/state dirs — imports stopped";
         threshold = 0;
       }
       {

--- a/modules/nixos/services/cratedigger.nix
+++ b/modules/nixos/services/cratedigger.nix
@@ -54,7 +54,9 @@
   # backups), /mnt/appdata, /mnt/mum, /mnt/mirrors. The pipeline's real scope
   # is three paths: its virtiofs state/backups dir, the shared music tree
   # (beets library + Incoming + Re-download), and the slskd download staging
-  # on NFS. Blank /mnt and bind back exactly those. This is the single
+  # (cfg.downloadDir — on doc2 /mnt/virtio/music/slskd, lowercase, distinct
+  # from the capital-M /mnt/virtio/Music beets tree). Blank /mnt and bind
+  # back exactly those. This is the single
   # biggest blast-radius reduction in the #257 audit (root + everything → a
   # root process confined to its own music pipeline). NOT applied to the
   # gate/secrets/db-migrate/temp-clean oneshots — they touch only /run, /tmp,

--- a/modules/nixos/services/discogs.nix
+++ b/modules/nixos/services/discogs.nix
@@ -92,6 +92,8 @@ in {
           unitConfig = {
             StartLimitIntervalSec = "4h";
             StartLimitBurst = 4;
+            # #257: fail-loud mirror bind ordered after mnt-mirrors.mount.
+            RequiresMountsFor = [cfg.mirrorDir];
           };
           serviceConfig = {
             Type = "oneshot";
@@ -99,6 +101,10 @@ in {
             Restart = "on-failure";
             RestartSec = "15min";
             EnvironmentFile = config.sops.secrets."discogs-pgpass".path;
+            # #257: blank /mnt, bind back only the mirror dir this importer
+            # downloads dumps into. Was: full /mnt/* RW as root.
+            TemporaryFileSystem = "/mnt";
+            BindPaths = [cfg.mirrorDir];
             # Wrap so $POSTGRES_PASSWORD expands at runtime — keeps the password
             # out of /nix/store, which the bare DSN string would otherwise leak.
             ExecStart = pkgs.writeShellScript "discogs-import-start" ''
@@ -134,6 +140,12 @@ in {
             '';
             Restart = "on-failure";
             RestartSec = 5;
+            # #257: this API server is stateless (talks to the discogs-db
+            # nspawn container over TCP) and ran as root with the full /mnt/*
+            # tree RW. Harden it: ProtectSystem=strict + blank /mnt, nothing
+            # bound back. No NAMESPACE errorPattern — no bind source to fail.
+            ProtectSystem = "strict";
+            TemporaryFileSystem = "/mnt";
           };
         };
       };

--- a/modules/nixos/services/gotify-server.nix
+++ b/modules/nixos/services/gotify-server.nix
@@ -31,13 +31,23 @@ in {
     };
     users.groups.gotify = {};
 
-    # Override upstream service to use static user and custom data dir
-    systemd.services.gotify-server.serviceConfig = {
-      DynamicUser = lib.mkForce false;
-      User = "gotify";
-      Group = "gotify";
-      WorkingDirectory = lib.mkForce cfg.dataDir;
-      StateDirectory = lib.mkForce "";
+    # Override upstream service to use static user and custom data dir.
+    # #257: upstream gotify ships no sandboxing — full /mnt/* RW-visible.
+    # Gotify writes only its dataDir (db, uploads, plugins), so add
+    # ProtectSystem=strict + blank /mnt bound to that one virtiofs dir.
+    # RequiresMountsFor orders the fail-loud bind after mnt-virtio.mount.
+    systemd.services.gotify-server = {
+      unitConfig.RequiresMountsFor = [cfg.dataDir];
+      serviceConfig = {
+        DynamicUser = lib.mkForce false;
+        User = "gotify";
+        Group = "gotify";
+        WorkingDirectory = lib.mkForce cfg.dataDir;
+        StateDirectory = lib.mkForce "";
+        ProtectSystem = "strict";
+        TemporaryFileSystem = "/mnt";
+        BindPaths = [cfg.dataDir];
+      };
     };
 
     networking.firewall.allowedTCPPorts = [8050];
@@ -64,7 +74,7 @@ in {
         {
           name = "Gotify server failure";
           unit = "gotify-server.service";
-          pattern = "(?i)panic|fatal|listen tcp.*bind";
+          pattern = "(?i)panic|fatal|listen tcp.*bind|Failed at step NAMESPACE";
           severity = "critical";
           summary = "Gotify server crashed — push notifications offline";
           # Single-shot: panic/fatal lines emit once before the process

--- a/modules/nixos/services/mealie.nix
+++ b/modules/nixos/services/mealie.nix
@@ -68,6 +68,13 @@ in {
         config.systemd.units."container@mealie-db.service".unit
         config.sops.secrets."mealie-pgpass".path
       ];
+      # #257: blank /mnt. Mealie's state is already bound from its virtiofs
+      # dataDir onto /var/lib/mealie (below) — which is NOT under /mnt — so
+      # nothing else needs binding back; TemporaryFileSystem just masks the
+      # host's /mnt/* tree the unit was needlessly inheriting. The DB lives in
+      # the mealie-db nspawn container, reached over TCP. RequiresMountsFor
+      # keeps the fail-loud dataDir bind ordered after mnt-virtio.mount.
+      unitConfig.RequiresMountsFor = lib.mkIf (cfg.dataDir != "/var/lib/mealie") [cfg.dataDir];
       serviceConfig =
         {
           DynamicUser = lib.mkForce false;
@@ -76,6 +83,7 @@ in {
           # list is [mealie/env, mealie-pgpass] without duplicates.
           # systemd merges multiple EnvironmentFile= entries; later wins.
           EnvironmentFile = lib.mkAfter [config.sops.secrets."mealie-pgpass".path];
+          TemporaryFileSystem = "/mnt";
         }
         // lib.optionalAttrs (cfg.dataDir != "/var/lib/mealie") {
           BindPaths = ["${cfg.dataDir}:/var/lib/mealie"];
@@ -116,7 +124,7 @@ in {
           name = "Mealie DB connection failure";
           unit = "mealie.service";
           # Worker SIGTERM is graceful reload — excluded.
-          pattern = "(?i)password authentication failed for user \"mealie\"|Error connecting to database";
+          pattern = "(?i)password authentication failed for user \"mealie\"|Error connecting to database|Failed at step NAMESPACE";
           severity = "critical";
           summary = "Mealie cannot reach its DB";
           description = "Matches the #232 trust→scram regression class.";

--- a/modules/nixos/services/tautulli.nix
+++ b/modules/nixos/services/tautulli.nix
@@ -23,6 +23,21 @@ in {
       configFile = "${cfg.dataDir}/config.ini";
     };
 
+    # #257: upstream tautulli ships no sandboxing — it ran with the host's
+    # full /mnt/* tree RW-visible. Tautulli writes only to its virtiofs
+    # dataDir (config, db, logs, cache, backups), so add ProtectSystem=strict
+    # and blank /mnt to just that one bound dir. RequiresMountsFor orders the
+    # fail-loud bind after mnt-virtio.mount.
+    # See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
+    systemd.services.tautulli = {
+      unitConfig.RequiresMountsFor = [cfg.dataDir];
+      serviceConfig = {
+        ProtectSystem = "strict";
+        TemporaryFileSystem = "/mnt";
+        BindPaths = [cfg.dataDir];
+      };
+    };
+
     homelab = {
       localProxy.hosts = [
         {
@@ -38,10 +53,19 @@ in {
         }
       ];
 
-      # See #253 audit. Skipped — Plex stats viewer with no actionable
-      # failure log fingerprint; outages surface via the Kuma HTTP
-      # monitor above.
-      monitoring.errorPatterns = [];
+      # See #253 audit. Plex stats viewer with no actionable failure log
+      # fingerprint (outages surface via the Kuma HTTP monitor above) — the
+      # only entry is the #257 fail-loud bind of its virtiofs dataDir.
+      monitoring.errorPatterns = [
+        {
+          name = "Tautulli namespace failure";
+          unit = "tautulli.service";
+          pattern = "(?i)Failed at step NAMESPACE";
+          severity = "warning";
+          summary = "tautulli cannot bind its virtiofs dataDir";
+          threshold = 0;
+        }
+      ];
     };
   };
 }

--- a/modules/nixos/services/webdav.nix
+++ b/modules/nixos/services/webdav.nix
@@ -27,10 +27,23 @@ in {
       };
     };
 
-    # WebDAV needs NFS mount for Zotero library
+    # WebDAV needs NFS mount for Zotero library — and ONLY that one dir.
+    # #257: was unhardened with the full /mnt/* tree RW-visible. The server
+    # serves exactly `directory` above, so blank /mnt and bind back only the
+    # Zotero Library subdir (rw — permissions=CRUD). The source path has a
+    # literal space, escaped `\ ` per systemd.exec(5); bound to the same
+    # space-bearing path so the `directory` setting needs no change.
+    # ProtectSystem=strict on top (simple Go file server, writes only there).
+    # See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
     systemd.services.webdav = {
       after = ["mnt-data.mount"];
       requires = ["mnt-data.mount"];
+      unitConfig.RequiresMountsFor = ["/mnt/data/Life/Andy/Education/Zotero Library"];
+      serviceConfig = {
+        ProtectSystem = "strict";
+        TemporaryFileSystem = "/mnt";
+        BindPaths = [''/mnt/data/Life/Andy/Education/Zotero\ Library''];
+      };
     };
 
     sops.secrets."webdav/env" = {
@@ -58,10 +71,20 @@ in {
         }
       ];
 
-      # See #253 audit. Skipped — simple file server with no actionable
-      # failure log fingerprint; NFS-backed outages already covered by
-      # the nfsWatchdog above and the Kuma HTTP monitor.
-      monitoring.errorPatterns = [];
+      # See #253 audit. Simple file server; NFS-backed outages already
+      # covered by the nfsWatchdog above + Kuma HTTP monitor — the only
+      # entry is the #257 fail-loud bind of the Zotero Library NFS dir.
+      monitoring.errorPatterns = [
+        {
+          name = "WebDAV namespace failure";
+          unit = "webdav.service";
+          pattern = "(?i)Failed at step NAMESPACE";
+          severity = "warning";
+          summary = "webdav cannot bind the Zotero Library NFS dir";
+          description = "BindPaths source on /mnt/data is missing or stale — check mnt-data.mount on doc2.";
+          threshold = 0;
+        }
+      ];
     };
   };
 }


### PR DESCRIPTION
Second batch of the #257 doc2 `/mnt` visibility audit — the **Class C** unhardened set (`ProtectSystem=no`, full `/mnt` **RW**-visible). Each sub-batch was deployed to doc2 and verified (`/proc/<pid>/mountinfo` narrowed + endpoint live) before the next.

## What

| Service | Shape | Notes |
|---|---|---|
| tautulli, gotify-server | `ProtectSystem=strict` + bind 1 virtiofs dataDir | sole path each writes |
| discogs-api | `ProtectSystem=strict` + blank `/mnt`, no bind | stateless root API |
| discogs-import | blank `/mnt` + bind mirror dir | monthly root oneshot |
| mealie | blank `/mnt` only | state already binds virtiofs→`/var/lib/mealie` |
| fava (+clone/pull) | `ProtectSystem=strict` + bind dataDir | replaced fava's `ReadWritePaths` |
| webdav | `ProtectSystem=strict` + bind **only** the Zotero NFS dir | space-bearing path, escaped |
| audiobookshelf (+cache-cleanup) | blank `/mnt` + state + declared library dirs | new `libraryDirs` option |
| cratedigger ×6 app units | blank `/mnt` + state + `/mnt/virtio/Music` + `cfg.downloadDir` | **biggest win** |

## Highlights / least-privilege notes

- **cratedigger** ran as **root** seeing the entire `/mnt` tree — including the pfSense ZFS backups (`/mnt/backup/pfsense`), `/mnt/appdata`, `/mnt/mum`. Now confined to its three pipeline paths. Validated live: the import pipeline was actively downloading + matching tracks inside the new sandbox with zero namespace/path errors.
- **audiobookshelf** similarly saw `/mnt/backup/pfsense` etc.; now bound to its virtiofs state + the real library path (`/mnt/data/Media/Books/Audiobooks`, surfaced from the ABS DB — the audit's `/mnt/data/Media/Audiobooks` guess didn't exist). Library scope is now a declarative `libraryDirs` option.
- `ProtectSystem=strict` added only where the writable-path set is known; skipped for the large Node/Python apps (ABS, cratedigger) where `/mnt` narrowing is the win.
- `RequiresMountsFor` on every fail-loud bind; `NAMESPACE` errorPatterns on units that bind a real source.

## Deploy notes

Restarts the listed units on doc2 — all verified active + serving post-deploy (tautulli 303, gotify 200, mealie 200, discogs health ok, fava 302, webdav 401-auth, ABS 200, cratedigger web 200 + live import).

Remaining from #257: Class D / immich (separate batch). Class E (kopia, nspawn DBs) is intentionally left broad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)