### PR TITLE
Sandbox /mnt: nginx secure-by-default + immich + grafana (#257 Class D)

### DIFF
--- a/docs/wiki/infrastructure/systemd-sandbox-mnt.md
+++ b/docs/wiki/infrastructure/systemd-sandbox-mnt.md
@@ -125,7 +125,33 @@ The unhardened set (`ProtectSystem=no`, full `/mnt` **RW**-visible). Done in thr
 - **Verify against the resolved value, not the module default.** cratedigger's `downloadDir` default is `/mnt/data/Media/Temp/slskd`, but doc2 overrides it to `/mnt/virtio/music/slskd` (lowercase, ≠ the capital-M `/mnt/virtio/Music` beets tree). Always read the actual `systemctl show -p BindPaths` and the host override, not the option default, when sanity-checking a namespace.
 - **Audit guesses need confirming.** The audit listed audiobookshelf's library as `/mnt/data/Media/Audiobooks`; the real path (from the ABS sqlite DB) is `/mnt/data/Media/Books/Audiobooks`. Pulled it from `libraryFolders` rather than trusting the issue.
 
-### Remaining (follow-up batches)
+### Batch 3 — Class D / immich + nginx (landed 2026-06-07)
 
-- **Class D / immich** — `immich-server` (shares mount namespace with ML subprocess + asset-edit machinery), `immich-machine-learning`, plus free wins on nginx/grafana (`PrivateMounts=yes` + blank `/mnt`).
+| Service | Shape | Notes |
+|---|---|---|
+| immich-server | blank `/mnt` + bind `mediaLocation` | only the photo library; DB over TCP so private namespace is safe (the old "loses nspawn nspath" worry was moot — it already ran `PrivateMounts=yes`) |
+| immich-machine-learning | blank `/mnt` + bind `MACHINE_LEARNING_CACHE_FOLDER` when under `/mnt` | virtiofs model cache |
+| grafana | blank `/mnt` + bind `cfg.dataDir/grafana` | data dir is on virtiofs (= WorkingDirectory); sandbox lives in `loki-server.nix` which owns the path |
+| nginx | **secure-by-default**: blank `/mnt` in the shared `homelab.nginx` module | see below |
+
+**The nginx secure-by-default pattern (the important one).** Rather than enumerate which hosts' nginx is "just a proxy," `homelab.nginx` now sets `TemporaryFileSystem=/mnt` unconditionally — so every host, and every future VM, starts with nginx blind to `/mnt`. Any module that defines an nginx vhost serving static files from `/mnt` **opens that one hole itself**, co-located with the vhost:
+
+```nix
+# in the module that sets `services.nginx.virtualHosts.<x>.root = <path under /mnt>`
+systemd.services.nginx = {
+  unitConfig.RequiresMountsFor = [ <root> ];
+  serviceConfig.BindPaths = [ <root> ];   # list-merges across modules
+};
+```
+
+Done for `podcast.nix` (`/mnt/data/Media/Podcasts` on doc1). Audited every fleet `services.nginx...root`: only podcast is under `/mnt` (smokeping → `/var/lib`, nix cache → `/var/cache`, meelo default → `/var/lib` and disabled). This means a future static-from-`/mnt` vhost that forgets the bind fails **loud** (nginx `226/NAMESPACE`) instead of silently widening the blast radius — the failure mode points you straight at the missing `BindPaths`.
+
+**Class D learnings:**
+
+- **Read the actual `WorkingDirectory`/env, not assumptions.** grafana looked like a "needs nothing under `/mnt`" free win, but its data dir is `cfg.dataDir/grafana` on virtiofs → a no-bind blank `/mnt` failed `200/CHDIR`. Same lesson as cratedigger's `downloadDir`: confirm against the running unit.
+- **Put the bind where the path is defined.** grafana's sandbox went in `loki-server.nix` (owns `services.grafana.dataDir`), not `alerting.nix` (only adds restartTriggers). Keeps the `/mnt` hole next to the path it needs.
+
+### Remaining
+
+- **LGTM siblings** (tempo, mimir, loki) have the same virtiofs-`WorkingDirectory` shape as grafana and could get the same treatment — not in the original audit's class list, follow-up if desired.
 - **Class E** (kopia-mum/photos, nspawn `*-db` containers) — legitimately broad / already tight, leave alone.

--- a/modules/nixos/services/alerting.nix
+++ b/modules/nixos/services/alerting.nix
@@ -1072,12 +1072,8 @@ in {
           restartTriggers = [
             config.systemd.units."grafana-alerting-prestart.service".unit
           ];
-          # #257: grafana needs nothing under /mnt but inherited doc2's whole
-          # /mnt/* tree (incl. /mnt/backup/pfsense, /mnt/appdata, /mnt/mum).
-          # Blank it — TemporaryFileSystem forces a private mount namespace
-          # (upstream leaves PrivateMounts=no). No bind source → no NAMESPACE
-          # errorPattern. See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
-          serviceConfig.TemporaryFileSystem = "/mnt";
+          # #257 /mnt sandbox for grafana lives in loki-server.nix (which owns
+          # services.grafana.dataDir) so the bind path stays co-located.
         };
       };
     };

--- a/modules/nixos/services/alerting.nix
+++ b/modules/nixos/services/alerting.nix
@@ -1072,6 +1072,12 @@ in {
           restartTriggers = [
             config.systemd.units."grafana-alerting-prestart.service".unit
           ];
+          # #257: grafana needs nothing under /mnt but inherited doc2's whole
+          # /mnt/* tree (incl. /mnt/backup/pfsense, /mnt/appdata, /mnt/mum).
+          # Blank it — TemporaryFileSystem forces a private mount namespace
+          # (upstream leaves PrivateMounts=no). No bind source → no NAMESPACE
+          # errorPattern. See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
+          serviceConfig.TemporaryFileSystem = "/mnt";
         };
       };
     };

--- a/modules/nixos/services/immich.nix
+++ b/modules/nixos/services/immich.nix
@@ -6,6 +6,11 @@
 }: let
   cfg = config.homelab.services.immich;
 
+  # #257 sandbox paths (see immich-server / immich-machine-learning below).
+  mediaLocation = config.services.immich.mediaLocation;
+  mlCache = config.services.immich.machine-learning.environment.MACHINE_LEARNING_CACHE_FOLDER or "/var/cache/immich";
+  mlCacheUnderMnt = lib.hasPrefix "/mnt" mlCache;
+
   # Extension-creation SQL — replicated from upstream's unguarded ExecStartPost
   # (nixpkgs #388806). We run this inside the container instead.
   immichExtensionSQL = ''
@@ -158,10 +163,33 @@ in {
         after = ["container@immich-db.service"];
         requires = ["container@immich-db.service"];
         restartTriggers = [config.systemd.units."container@immich-db.service".unit];
-        # Inject pgpass into immich-server's EnvironmentFile after immich/env
-        # (which `secretsFile` populates). Later entries win in systemd.
-        serviceConfig.EnvironmentFile =
-          lib.mkAfter [config.sops.secrets."immich-pgpass".path];
+        # #257: immich-server inherited doc2's whole /mnt tree (incl.
+        # /mnt/backup/pfsense, /mnt/appdata, /mnt/mum). Its only legit /mnt
+        # path is the photo library (mediaLocation); the DB is reached over
+        # TCP via the immich-db nspawn container, so a private /mnt namespace
+        # doesn't affect it. Blank /mnt, bind only the library. NOT adding
+        # ProtectSystem here (immich-server's full writable-path set is
+        # unpinned) — the /mnt narrowing is the #257 win.
+        # See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
+        unitConfig.RequiresMountsFor = [mediaLocation];
+        serviceConfig = {
+          # Inject pgpass into immich-server's EnvironmentFile after immich/env
+          # (which `secretsFile` populates). Later entries win in systemd.
+          EnvironmentFile = lib.mkAfter [config.sops.secrets."immich-pgpass".path];
+          TemporaryFileSystem = "/mnt";
+          BindPaths = [mediaLocation];
+        };
+      };
+
+      # #257: machine-learning downloads/caches models to a virtiofs dir on
+      # doc2 (MACHINE_LEARNING_CACHE_FOLDER). Blank /mnt and bind only that
+      # cache when it lives under /mnt (on a host using the /var/cache default
+      # there's nothing to bind — the blank tmpfs alone is the win).
+      immich-machine-learning = {
+        unitConfig = lib.mkIf mlCacheUnderMnt {RequiresMountsFor = [mlCache];};
+        serviceConfig =
+          {TemporaryFileSystem = "/mnt";}
+          // lib.optionalAttrs mlCacheUnderMnt {BindPaths = [mlCache];};
       };
     };
 
@@ -211,7 +239,7 @@ in {
           # for table) plus any pg_dump backup failure. Skips noisy
           # ERR_HTTP_HEADERS_SENT and "Failed to fetch latest release"
           # — those are warns, not service-broken.
-          pattern = "(?i)permission denied for table|pg_dump non-zero exit code|Database Backup Failure";
+          pattern = "(?i)permission denied for table|pg_dump non-zero exit code|Database Backup Failure|Failed at step NAMESPACE";
           severity = "critical";
           summary = "Immich app is throwing DB errors — uploads likely broken";
           description = ''

--- a/modules/nixos/services/loki-server.nix
+++ b/modules/nixos/services/loki-server.nix
@@ -195,8 +195,20 @@ in {
 
       services = {
         # Grafana admin creds injected via env so they never hit the Nix store.
-        grafana.serviceConfig.EnvironmentFile =
-          config.sops.secrets."loki/grafana.env".path;
+        # #257: grafana inherited doc2's whole /mnt/* tree (incl.
+        # /mnt/backup/pfsense, /mnt/appdata, /mnt/mum). Its only legit /mnt
+        # path is its own data dir on virtiofs (= cfg.dataDir/grafana, also
+        # its WorkingDirectory). Blank /mnt and bind only that. Done here
+        # rather than in alerting.nix because this module owns the dataDir.
+        # See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
+        grafana = {
+          unitConfig.RequiresMountsFor = ["${cfg.dataDir}/grafana"];
+          serviceConfig = {
+            EnvironmentFile = config.sops.secrets."loki/grafana.env".path;
+            TemporaryFileSystem = "/mnt";
+            BindPaths = ["${cfg.dataDir}/grafana"];
+          };
+        };
 
         tempo.serviceConfig = {
           DynamicUser = lib.mkForce false;

--- a/modules/nixos/services/nginx.nix
+++ b/modules/nixos/services/nginx.nix
@@ -72,5 +72,21 @@ in {
     };
 
     users.users.nginx.extraGroups = ["acme"];
+
+    # #257: secure-by-default — blank nginx's /mnt in the shared module so
+    # every host (and every future VM) starts with nginx unable to see the
+    # /mnt/* tree it almost never needs. nginx already runs
+    # ProtectSystem=strict + PrivateMounts=yes, but those leave the
+    # user-managed /mnt mounts visible; TemporaryFileSystem masks them.
+    #
+    # A reverse-proxy nginx (e.g. doc2) needs nothing bound back. Any host
+    # that ALSO serves static files from /mnt opens that hole explicitly in
+    # the module that defines the vhost, by adding the path to
+    # `systemd.services.nginx.serviceConfig.BindPaths` + a matching
+    # `RequiresMountsFor` (see podcast.nix for the pattern). This keeps the
+    # /mnt hole co-located with the config that needs it, so it can't be
+    # forgotten when a service moves hosts.
+    # See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
+    systemd.services.nginx.serviceConfig.TemporaryFileSystem = "/mnt";
   };
 }

--- a/modules/nixos/services/podcast.nix
+++ b/modules/nixos/services/podcast.nix
@@ -263,6 +263,16 @@ in {
   # 6. SOPS Secret
   # REMOVED: Managed centrally by homelab.nginx
 
+  # #257: homelab.nginx blanks /mnt by default (secure-by-default). This
+  # vhost serves static files from podcastDir on NFS, so bind that one path
+  # back into nginx's sandbox and order nginx after the mount. Without this
+  # the fail-loud bind / blanked tmpfs would 404 every podcast request (or
+  # fail nginx start). Co-located here so the hole travels with the vhost.
+  systemd.services.nginx = {
+    unitConfig.RequiresMountsFor = [podcastDir];
+    serviceConfig.BindPaths = [podcastDir];
+  };
+
   # 7. Nginx Configuration
   services.nginx = {
     virtualHosts."${domain}" = {


### PR DESCRIPTION
Final batch of the #257 doc2 `/mnt` audit — Class D / immich, plus the **nginx secure-by-default** change (touches doc1 + doc2). Verified on both hosts.

## What

| Service | Host | Shape |
|---|---|---|
| nginx | **all** | blank `/mnt` by default in `homelab.nginx`; static-from-`/mnt` vhosts bind their own hole |
| podcast | doc1 | binds `/mnt/data/Media/Podcasts` back into nginx |
| immich-server | doc2 | blank `/mnt` + bind `mediaLocation` (DB over TCP) |
| immich-machine-learning | doc2 | blank `/mnt` + bind virtiofs model cache |
| grafana | doc2 | blank `/mnt` + bind `cfg.dataDir/grafana` (in loki-server.nix) |

## The nginx pattern (secure-by-default)

`homelab.nginx` now blanks `/mnt` unconditionally, so every host — and every future VM — starts with nginx unable to see `/mnt`. A module that serves static files from `/mnt` opens that one path itself, co-located with the vhost (`podcast.nix`). Audited every fleet `services.nginx...root`: only podcast is under `/mnt`. A future forgotten bind fails **loud** (`226/NAMESPACE`) rather than silently re-widening the blast radius.

## Verification

- doc1 nginx: 22 `/mnt` mounts (incl. `/mnt/backup/pfsense`) → **only** `/mnt/data/Media/Podcasts`; podcast vhost still HTTP 200; :80/:443 intact.
- doc2: immich-server (`/mnt/data/Life/Photos` only, `/api/server/ping` → pong), immich-ml (`ml-cache` only), grafana (dataDir only, `/api/health` DB ok), nginx (blank).

## Notes / surprises caught

- grafana looked like a no-`/mnt` free win but its data dir is on virtiofs → fixed the `200/CHDIR` by binding it.
- immich-server's "loses nspawn nspath under PrivateMounts" worry was moot — it already ran `PrivateMounts=yes` and reaches its DB over TCP.
- No `ProtectSystem` change on immich (writable-path set unpinned); `/mnt` narrowing is the win.

This completes the actionable scope of #257. LGTM siblings (tempo/mimir/loki, same virtiofs-WorkingDirectory shape) noted as optional follow-up; Class E (kopia, nspawn DBs) intentionally left broad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)