### PR TITLE
Sandbox /mnt: LGTM siblings, slskd + fleet sweep (#257)

### DIFF
--- a/docs/wiki/infrastructure/systemd-sandbox-mnt.md
+++ b/docs/wiki/infrastructure/systemd-sandbox-mnt.md
@@ -151,7 +151,27 @@ Done for `podcast.nix` (`/mnt/data/Media/Podcasts` on doc1). Audited every fleet
 - **Read the actual `WorkingDirectory`/env, not assumptions.** grafana looked like a "needs nothing under `/mnt`" free win, but its data dir is `cfg.dataDir/grafana` on virtiofs → a no-bind blank `/mnt` failed `200/CHDIR`. Same lesson as cratedigger's `downloadDir`: confirm against the running unit.
 - **Put the bind where the path is defined.** grafana's sandbox went in `loki-server.nix` (owns `services.grafana.dataDir`), not `alerting.nix` (only adds restartTriggers). Keeps the `/mnt` hole next to the path it needs.
 
+### Batch 4 — fleet sweep (landed 2026-06-07)
+
+After Class A–D, ran an empirical sweep on doc2 — for every running service, counted `/mnt` mounts in `/proc/<pid>/mountinfo` and checked for `TemporaryFileSystem`. Anything broad + unsandboxed got triaged:
+
+| Service | Action |
+|---|---|
+| tempo, mimir, loki | blank `/mnt` + bind each one's virtiofs state subdir (same as grafana) |
+| **slskd** | **a missed Class B item** — internet-facing P2P daemon seeing all of `/mnt` incl. `/mnt/backup/pfsense`. Blank + bind `downloadDir` (rw) and the shared library (read-only) |
+| redis-immich/-paperless/-cratedigger | blank `/mnt`, no bind (state in `/var/lib`) |
+| alert-bridge, smokeping (+fcgiwrap) | blank `/mnt`, no bind |
+
+**Deliberately left broad (verified out of scope):**
+
+- **OS daemons** — `sshd`, `systemd-*`, `nix-daemon`, `dbus-broker`, `NetworkManager`, `qemu-guest-agent`, etc. Root system services that need broad access. **`prometheus-node-exporter` specifically MUST see all mounts** — per-mount disk metrics are its job.
+- **OCI `podman-*`** — the 22-mount count is the podman *runtime's* host namespace; the container's own `/mnt` view is set by `--volume` flags, not systemd sandboxing.
+- **nspawn `container@*-db`** and **`kopia-mum`/`kopia-photos`** — Class E (DB scope tight via nspawn; kopia legitimately broad by design).
+- **`alloy-loki`** — log-collection agent; left for now (reads journal/targets, sandboxing risks breaking collection).
+
+**slskd switch-to-configuration race (important deploy gotcha).** On the deploy that added slskd's sandbox, slskd was *actively downloading*; `switch-to-configuration`'s live restart left it in a private mount namespace that still held the **old** (full-`/mnt`) mount table — `systemctl show` reported the new `TemporaryFileSystem=/mnt` + binds, but `/proc/<pid>/mountinfo` showed all 23 host mounts. A clean `systemctl restart slskd` applied it correctly (down to 4 mounts). So: **for a heavily-loaded service, verify the namespace actually narrowed after a deploy — don't trust `systemctl show`; read `mountinfo`.** A clean boot (e.g. the nightly rolling-update reboot) applies it correctly, so it self-heals; the live-restart-during-deploy is the only window where it can lag.
+
 ### Remaining
 
-- **LGTM siblings** (tempo, mimir, loki) have the same virtiofs-`WorkingDirectory` shape as grafana and could get the same treatment — not in the original audit's class list, follow-up if desired.
 - **Class E** (kopia-mum/photos, nspawn `*-db` containers) — legitimately broad / already tight, leave alone.
+- **`alloy-loki`** — optional; sandbox only after confirming its read targets.

--- a/modules/nixos/services/alert-bridge.nix
+++ b/modules/nixos/services/alert-bridge.nix
@@ -460,6 +460,10 @@ in {
         # internet. Minimal hardening only.
         NoNewPrivileges = true;
         PrivateTmp = true;
+        # #257: the bridge only queries Loki over HTTP + runs claude (reads
+        # ~/.claude, which is NOT under /mnt). It needs nothing on /mnt, so
+        # blank the tree it was needlessly inheriting.
+        TemporaryFileSystem = "/mnt";
       };
     };
   };

--- a/modules/nixos/services/cratedigger.nix
+++ b/modules/nixos/services/cratedigger.nix
@@ -505,6 +505,10 @@ in {
             };
           };
 
+          # #257: cratedigger's redis (job queue) stores in /var/lib — nothing
+          # under /mnt. Blank it.
+          redis-cratedigger.serviceConfig.TemporaryFileSystem = "/mnt";
+
           cratedigger-db-migrate = {
             after = ["container@cratedigger-db.service"];
             requires = ["container@cratedigger-db.service"];

--- a/modules/nixos/services/immich.nix
+++ b/modules/nixos/services/immich.nix
@@ -143,6 +143,11 @@ in {
     systemd.services = {
       postgresql-setup = lib.mkForce {};
 
+      # #257: redis (immich's cache/queue) stores in /var/lib and needs
+      # nothing under /mnt, but inherited the full /mnt/* tree. Blank it —
+      # localhost-bound cache, but a free blast-radius cut.
+      redis-immich.serviceConfig.TemporaryFileSystem = "/mnt";
+
       # Immich must wait for its database container.
       # restartTriggers: switch-to-configuration only restarts services whose unit
       # files changed.  When the container is restarted (its config changed),

--- a/modules/nixos/services/loki-server.nix
+++ b/modules/nixos/services/loki-server.nix
@@ -210,22 +210,43 @@ in {
           };
         };
 
-        tempo.serviceConfig = {
-          DynamicUser = lib.mkForce false;
-          User = "tempo";
-          Group = "tempo";
-          WorkingDirectory = lib.mkForce "${cfg.dataDir}/tempo";
-          StateDirectory = lib.mkForce "";
-          ReadWritePaths = ["${cfg.dataDir}/tempo"];
+        # #257: tempo/mimir/loki had the same broad-/mnt shape as grafana
+        # (virtiofs WorkingDirectory, whole /mnt/* tree visible). Blank /mnt
+        # and bind only each one's own state subdir. BindPaths replaces the
+        # old ReadWritePaths (rw by default, fail-loud). RequiresMountsFor
+        # orders each after mnt-virtio.mount.
+        tempo = {
+          unitConfig.RequiresMountsFor = ["${cfg.dataDir}/tempo"];
+          serviceConfig = {
+            DynamicUser = lib.mkForce false;
+            User = "tempo";
+            Group = "tempo";
+            WorkingDirectory = lib.mkForce "${cfg.dataDir}/tempo";
+            StateDirectory = lib.mkForce "";
+            TemporaryFileSystem = "/mnt";
+            BindPaths = ["${cfg.dataDir}/tempo"];
+          };
         };
 
-        mimir.serviceConfig = {
-          DynamicUser = lib.mkForce false;
-          User = "mimir";
-          Group = "mimir";
-          WorkingDirectory = lib.mkForce "${cfg.dataDir}/mimir";
-          StateDirectory = lib.mkForce "";
-          ReadWritePaths = ["${cfg.dataDir}/mimir"];
+        mimir = {
+          unitConfig.RequiresMountsFor = ["${cfg.dataDir}/mimir"];
+          serviceConfig = {
+            DynamicUser = lib.mkForce false;
+            User = "mimir";
+            Group = "mimir";
+            WorkingDirectory = lib.mkForce "${cfg.dataDir}/mimir";
+            StateDirectory = lib.mkForce "";
+            TemporaryFileSystem = "/mnt";
+            BindPaths = ["${cfg.dataDir}/mimir"];
+          };
+        };
+
+        loki = {
+          unitConfig.RequiresMountsFor = ["${cfg.dataDir}/loki"];
+          serviceConfig = {
+            TemporaryFileSystem = "/mnt";
+            BindPaths = ["${cfg.dataDir}/loki"];
+          };
         };
       };
     };

--- a/modules/nixos/services/paperless.nix
+++ b/modules/nixos/services/paperless.nix
@@ -179,6 +179,10 @@ in {
       # NAMESPACE errorPattern (#257).
       gotenberg.serviceConfig.TemporaryFileSystem = "/mnt";
       tika.serviceConfig.TemporaryFileSystem = "/mnt";
+
+      # paperless's redis (task broker) stores in /var/lib — nothing under
+      # /mnt. Blank it (#257).
+      redis-paperless.serviceConfig.TemporaryFileSystem = "/mnt";
     };
 
     # Paperless user needs NFS access

--- a/modules/nixos/services/slskd.nix
+++ b/modules/nixos/services/slskd.nix
@@ -123,7 +123,24 @@ in {
     # Slskd downloads are handed to root-run cratedigger, then Beets/operator
     # tooling needs group access after import. Keep that boundary on the
     # dedicated music-import group instead of world-writable files.
-    systemd.services.slskd.serviceConfig.UMask = "0002";
+    #
+    # #257: slskd is an internet-facing P2P daemon — a large attack surface —
+    # yet it ran with the host's whole /mnt/* tree visible (incl.
+    # /mnt/backup/pfsense, /mnt/appdata, /mnt/mum). Blank /mnt and bind only
+    # its two legit paths: the download dir (rw) and the shared music library
+    # (read-only — slskd serves it to peers, never writes it). A compromised
+    # slskd can now reach nothing else on /mnt. RequiresMountsFor orders the
+    # fail-loud binds after their mounts.
+    # See docs/wiki/infrastructure/systemd-sandbox-mnt.md.
+    systemd.services.slskd = {
+      unitConfig.RequiresMountsFor = [cfg.downloadDir cfg.musicDir];
+      serviceConfig = {
+        UMask = "0002";
+        TemporaryFileSystem = "/mnt";
+        BindPaths = [cfg.downloadDir];
+        BindReadOnlyPaths = [cfg.musicDir];
+      };
+    };
 
     users = {
       groups.music-import = {};
@@ -152,10 +169,21 @@ in {
         }
       ];
 
-      # See #253 audit. Skipped — Soulseek client where peer/network
-      # errors are normal operation, not an actionable failure
-      # fingerprint. Outages surface via the Kuma HTTP monitor above.
-      monitoring.errorPatterns = [];
+      # See #253 audit. Soulseek client where peer/network errors are normal
+      # operation, not an actionable fingerprint (outages surface via the
+      # Kuma HTTP monitor above) — the only entry is the #257 fail-loud bind
+      # of its music paths.
+      monitoring.errorPatterns = [
+        {
+          name = "slskd namespace failure";
+          unit = "slskd.service";
+          pattern = "(?i)Failed at step NAMESPACE";
+          severity = "warning";
+          summary = "slskd cannot bind its download/music dirs";
+          description = "A BindPaths source (downloadDir or musicDir) is missing or stale — check the backing mount on doc2.";
+          threshold = 0;
+        }
+      ];
     };
   };
 }

--- a/modules/nixos/services/smokeping.nix
+++ b/modules/nixos/services/smokeping.nix
@@ -12,6 +12,13 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
+    # #257: smokeping + its fcgiwrap serve/store entirely under
+    # ${smokepingHome} (/var/lib/smokeping) — nothing on /mnt. Blank the
+    # tree both units needlessly inherited. /var/lib-only, so safe on any
+    # host that enables smokeping (currently doc2).
+    systemd.services.smokeping.serviceConfig.TemporaryFileSystem = "/mnt";
+    systemd.services.fcgiwrap-smokeping.serviceConfig.TemporaryFileSystem = "/mnt";
+
     services = {
       smokeping = {
         enable = true;


### PR DESCRIPTION
Follow-up sweep after Class A–D. Ran an empirical `/proc/<pid>/mountinfo` audit across every running doc2 service to catch anything still inheriting the full `/mnt` tree.

## What

| Service | Shape |
|---|---|
| tempo, mimir, loki | blank `/mnt` + bind each one's virtiofs state subdir (same as grafana) |
| **slskd** | **missed Class B item** — internet-facing P2P daemon that saw all of `/mnt` incl. the pfSense backups. Blank + bind `downloadDir` (rw) and the shared library **read-only** (it serves Beets to peers, never writes it) |
| redis-immich/-paperless/-cratedigger | blank `/mnt`, no bind |
| alert-bridge, smokeping (+fcgiwrap) | blank `/mnt`, no bind |

## Out of scope (verified, documented)

OS daemons (sshd/systemd-*/nix-daemon — need system access; **node-exporter must see all mounts**), OCI `podman-*` (`/mnt` via `--volume`, not systemd), nspawn `container@*-db` + `kopia-*` (Class E), `alloy-loki` (log agent, deferred).

## Verification

All units verified active + `/mnt` narrowed via `mountinfo`. slskd hit a switch-to-configuration race (it was mid-download — the live restart kept the old mount table despite `systemctl show` reporting the new config); a clean restart applied it (23 → 4 mounts). Documented as a deploy gotcha — a clean boot applies it correctly, so it self-heals on the nightly reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)