### PR TITLE
ssh: doc1 bastion — keyless siblings, declarative key-only entry (closes #270, gates #241)

### DIFF
--- a/docs/wiki/infrastructure/github-pat-and-private-inputs.md
+++ b/docs/wiki/infrastructure/github-pat-and-private-inputs.md
@@ -1,7 +1,24 @@
 # GitHub PAT rotation & private flake inputs
 
-**Status**: working (Phase 1 shipped 2026-04-17, Phase 2 pending).
-**Issue**: [#210](https://github.com/abl030/nixosconfig/issues/210) — the incident that motivated this.
+**Status**: Phase 1 shipped 2026-04-17. **Phase 2 (git+ssh) was CANCELLED —
+superseded by the #270 bastion model (2026-06-08).**
+**Issue**: [#210](https://github.com/abl030/nixosconfig/issues/210) — the incident that motivated this. [#270](https://github.com/abl030/nixosconfig/issues/270) — the bastion that superseded Phase 2.
+
+> ### ⚠️ Superseded direction (read first)
+> Phase 2 proposed moving `vinsight-mcp` to `git+ssh://` so PAT rotation
+> couldn't break private-input fetches. **#270 went the opposite way:** it
+> made every host except the doc1 bastion *keyless*, so an SSH key on every
+> host is exactly the skeleton-key blast radius #270 removes. Instead,
+> `vinsight-mcp` + `cellar-manager` fetch via `github:` + the read-only
+> `nix-netrc` PAT on every host, and the `rootFleetIdentity` mirror + the
+> github `Match` block were deleted.
+>
+> **New trade-off:** a dead/expired PAT now fails eval of the two *private*
+> inputs fleet-wide (public inputs still resolve via the empty-token degrade
+> below). Mitigation: a **no-expiry**, Contents:read, 2-repo fine-grained PAT
+> — scope is the protection, not the clock. The keyless model is documented in
+> [ssh-bastion-model.md](./ssh-bastion-model.md). The Phase 1 pieces below
+> (`refresh-access-tokens.nix`) are still live and still the resilience layer.
 
 ## Problem we're solving
 

--- a/docs/wiki/infrastructure/ssh-bastion-model.md
+++ b/docs/wiki/infrastructure/ssh-bastion-model.md
@@ -1,0 +1,81 @@
+# SSH bastion model — doc1 as the sole fleet-key holder
+
+**Status:** live (shipped via [#270](https://github.com/abl030/nixosconfig/issues/270), 2026-06-08). No-infra interim ahead of the full CA architecture in [#241](https://github.com/abl030/nixosconfig/issues/241).
+**Researched/written:** 2026-06-08 (during the #270 work + its ce-code-review pass).
+
+## The problem it solves
+
+Before #270, every host deployed the **same** fleet SSH private key
+(`ssh_key_abl030`) to `~/.ssh/id_ed25519` and authorized it. Pop **any** host →
+read that file → it *is* the fleet skeleton key → SSH to every other host. One
+compromised host = the whole fleet. sshd also honored hand-edited
+`~/.ssh/authorized_keys` files holding stray/unknown keys outside `hosts.nix`.
+
+## The model
+
+- **doc1 (proxmox-vm) is the bastion** — the ONLY host that holds the fleet
+  identity private key (`homelab.ssh.deployIdentity = true`; the module default
+  is now **false**, enforced by `bastionInvariantCheck` in `flake.nix`).
+- **Every sibling is keyless.** It trusts only `fleetKeys = [fleetIdentity]`
+  inbound (so doc1 can reach it) but holds no fleet key, so a popped sibling
+  can't move laterally. Verified: `sibling → other-sibling` = Permission denied.
+- **Entry to doc1** = per-device **passphrase** keys (`bastionDeviceKeys`:
+  epi/framework/wsl) + the phone, each `from="100.64.0.0/10,192.168.1.0/24"`
+  pinned (tailnet + home LAN only), with `ssh.secure = true` (no password auth,
+  no root login). The passphrase is the real gate; `from=` bounds where it can
+  be presented.
+- **Authorization is 100% declarative.** `authorizedKeysInHomedir = false` →
+  sshd reads ONLY `/etc/ssh/authorized_keys.d/%u` rendered from `hosts.nix`. The
+  hand-edited `~/.ssh/authorized_keys` surface is closed (an audit found stray
+  unknown keys even on the bastion itself).
+- **Access pattern = stepping-stone.** Land on doc1 with `~/.ssh/id_doc1`
+  (`ssh -i ~/.ssh/id_doc1 doc1`), then reach siblings *from* doc1 using its
+  resident fleet key. ProxyJump does NOT work here (siblings don't trust your
+  device keys, so `ssh -J doc1 sibling` is rejected at the sibling) — you hop.
+- **Claude/agents run on doc1**, so the autonomous deploy path (#241's
+  load-bearing constraint) is unchanged: Claude-on-doc1 → keyless siblings.
+
+## Key files
+
+| File | Role |
+|---|---|
+| `hosts.nix` (`let` block) | `fleetIdentity`, `fleetKeys`, `bastionDeviceKeys`, `phoneKey`, `bastionFrom`, `bastionKeys` |
+| `modules/nixos/services/ssh/default.nix` | `deployIdentity` (default false), `authorizedKeysInHomedir=false`, `purgeFleetKeyOnKeylessHost` activation script, github knownHosts pin |
+| `hosts/proxmox-vm/configuration.nix` | the one `deployIdentity = true` + `ssh.secure = true` |
+| `flake.nix` | `bastionInvariantCheck` — build fails unless exactly one `deployIdentity = true` |
+
+## Private flake inputs (the keyless enabler)
+
+The only `git+ssh://` input (`vinsight-mcp`) was the sole reason every host
+needed an SSH key. #270 re-pointed it to `github:` so it fetches via the
+read-only `nix-netrc` PAT (with `cellar-manager`). See
+[github-pat-and-private-inputs.md](./github-pat-and-private-inputs.md).
+**Trade-off:** a dead PAT fails eval of the two private inputs fleet-wide — use
+a **no-expiry**, Contents:read, 2-repo fine-grained token.
+
+## Gotchas / operational notes
+
+- **Break-glass:** Proxmox console on prom (console login is unaffected by
+  `secure=true`). If you lose all `bastionKeys`, that's the only way back in.
+- **Lateral service hops need a dedicated key.** A keyless host can't SSH to a
+  sibling with the fleet key any more. `gwm-archiver` on doc2 (which triggers
+  `marker-convert` on epi) hit this — fixed with a dedicated, **forced-command**
+  key (`secrets/hosts/doc2/gwm-trigger-key`, locked to `systemctl start
+  marker-convert.service` in `marker-convert.nix`). Copy this pattern for any
+  future keyless-host → sibling automation. `syncoid-pfsense` is the other
+  example.
+- **`purgeFleetKeyOnKeylessHost`** removes `/root/.ssh/id_ed25519` (real copy
+  from the old mirror) + the dangling `~/.ssh/id_ed25519` sops symlink husk on
+  every keyless switch. Only removes a *broken* user symlink, never a real key.
+- **caddy is HM-only** — outside the NixOS sshd domain, so `authorizedKeysInHomedir`
+  doesn't apply; its key surface is managed separately.
+- **wsl** reaches doc1 via the Windows host's *tailnet* IP (100.x), so the
+  `from=` belt admits it even though wsl physically sits on 192.168.100.x
+  (Cullen) — always connect via tailscale from Cullen.
+
+## When to revisit
+
+When [#241](https://github.com/abl030/nixosconfig/issues/241) (step-ca /
+CA-signed certs / YubiKey broker) lands — this bastion becomes the trust hub
+under it, or is replaced by short-lived certs. Open #241 Phase-1 hygiene item
+still pending: `forwardAgent = false` default in `modules/home-manager/services/ssh.nix`.

--- a/flake.lock
+++ b/flake.lock
@@ -888,15 +888,15 @@
       "locked": {
         "lastModified": 1771901753,
         "narHash": "sha256-F4wQ293vjwh2usqelMWBmVXIV2nuzK5rw0nUKyETiLM=",
-        "ref": "refs/heads/master",
+        "owner": "abl030",
+        "repo": "vinsight-mcp",
         "rev": "f3d1132db90b4da4be406c177cf2741f29a6c414",
-        "revCount": 70,
-        "type": "git",
-        "url": "ssh://git@github.com/abl030/vinsight-mcp"
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "ssh://git@github.com/abl030/vinsight-mcp"
+        "owner": "abl030",
+        "repo": "vinsight-mcp",
+        "type": "github"
       }
     },
     "yt-dlp-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -169,19 +169,26 @@
     };
 
     # Vinsight MCP - MCP server for Vinsight winery API.
-    # Private repo: fetched over SSH with the fleet identity deploy key
-    # (hosts.nix:masterKeys) so the rest of the flake stays resilient when
-    # the GitHub PAT rotates. See issue #210 and
-    # docs/wiki/infrastructure/github-pat-and-private-inputs.md.
+    # Private repo: fetched via github: using the read-only GitHub PAT in
+    # nix-netrc (access-tokens), NOT git+ssh. Moved off SSH in #270 so that no
+    # fleet host except the doc1 bastion needs an SSH key — siblings are keyless
+    # and a popped sibling holds nothing fleet-trusted.
+    # Trade-off (supersedes the #210 git+ssh rationale): a broken/expired PAT
+    # breaks eval of this input fleet-wide (vinsight is enabled by default in
+    # base.nix → in every host's closure). Keep the fine-grained token
+    # (vinsight-mcp + cellar-manager, Contents:read) on a long expiry and rotate
+    # before it lapses. refresh-access-tokens.nix degrades to empty-tokens on a
+    # rejected PAT, so public fetches still survive a lapse.
     vinsight-mcp = {
-      url = "git+ssh://git@github.com/abl030/vinsight-mcp";
+      url = "github:abl030/vinsight-mcp";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
     # cellar-manager - source tree for vinsight-local (FastAPI + sync tool)
-    # served on wsl at cullen.ablz.au. Public repo; consumed as plain source
-    # because the repo has no flake of its own — overlay.nix builds the
-    # vinsight-local Python package from this tree.
+    # served on wsl at cullen.ablz.au. Private repo (fetched via the same
+    # nix-netrc PAT as vinsight-mcp); consumed as plain source because the repo
+    # has no flake of its own — overlay.nix builds the vinsight-local Python
+    # package from this tree.
     cellar-manager = {
       url = "github:abl030/cellar-manager";
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -177,8 +177,11 @@
     # breaks eval of this input fleet-wide (vinsight is enabled by default in
     # base.nix → in every host's closure). Keep the fine-grained token
     # (vinsight-mcp + cellar-manager, Contents:read) on a long expiry and rotate
-    # before it lapses. refresh-access-tokens.nix degrades to empty-tokens on a
-    # rejected PAT, so public fetches still survive a lapse.
+    # before it lapses. On a rejected PAT, refresh-access-tokens.nix blanks the
+    # token so PUBLIC inputs still resolve — but this input and cellar-manager
+    # are PRIVATE, so they fail eval until the PAT is rotated. Prefer a no-expiry
+    # fine-grained token (scope is the protection, not the clock) to avoid a
+    # silent fleet-wide eval break. Old broad PAT must be revoked post-cutover.
     vinsight-mcp = {
       url = "github:abl030/vinsight-mcp";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -365,8 +368,30 @@
                         echo "on_lan gateway-MAC matcher behaves as specified."
                         touch $out
           '';
+
+          # Bastion invariant (#270): EXACTLY ONE host may hold the fleet identity
+          # private key — i.e. exactly one `deployIdentity = true` in the tree (the
+          # doc1 bastion; the module default is false). A future copy-paste that
+          # re-sets it true on a second host would silently re-spread the fleet
+          # skeleton key and undo the whole keyless-siblings model; 0 holders means
+          # nothing can reach the siblings. Either way, fail the build first.
+          bastionInvariantCheck = pkgs.runCommand "bastion-deployIdentity-invariant" {} ''
+            matches=$(${pkgs.gnugrep}/bin/grep -rnE "deployIdentity = true" ${./hosts} ${./modules} || true)
+            count=$(printf '%s' "$matches" | ${pkgs.gnugrep}/bin/grep -c . || true)
+            if [ "$count" != "1" ]; then
+              echo "BASTION INVARIANT VIOLATED (#270): expected exactly ONE host with"
+              echo "deployIdentity = true (the doc1 bastion), found $count:"
+              printf '%s\n' "$matches"
+              echo ""
+              echo "Only the doc1 bastion may hold the fleet identity private key."
+              echo "See issue #270 and modules/nixos/services/ssh/default.nix."
+              exit 1
+            fi
+            echo "Bastion invariant OK: exactly one deployIdentity=true (the doc1 bastion)."
+            touch $out
+          '';
         in
-          {inherit errorPatternsCheck onLanMatcherCheck;}
+          {inherit errorPatternsCheck onLanMatcherCheck bastionInvariantCheck;}
           // (
             if !fullCheck
             then {}

--- a/hosts.nix
+++ b/hosts.nix
@@ -24,6 +24,15 @@ let
     # Termux on Galaxy A55 — separate identity, revocable if phone is lost
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHmUU7BKMmjF53n0uCOg1w6uRe1erG13nembAiIE8ybN phone-fleet@s-a55"
   ];
+
+  # doc1 bastion entry keys — per-device, passphrase-protected, also on GitHub.
+  # Authorized on doc1 ONLY (the bastion's front door); siblings never trust these.
+  # The `from=` tailnet+LAN belt + doc1 narrowing land in Step 4. See issue #270.
+  bastionDeviceKeys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBl/6XgvT5NLe1R0Yu0Lduy/4nYnyDgAufGFppUJfUom abl030@epimetheus-bastion"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPyOTF8UNEwGkxNpzcdetGGShyX6aAG3BBk/8jLeCg11 abl030@framework-bastion"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEmXjAlxENRxMQ1qmw/K5nsLiHLFByywTqQdotRAye79 abl030@wsl-bastion"
+  ];
 in {
   epimetheus = {
     configurationFile = ./hosts/epi/configuration.nix;
@@ -95,7 +104,9 @@ in {
     sshAlias = "doc1";
     sshKeyName = "ssh_key_abl030";
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOJrhodI7gb1zaitbZayGHtpc+CO3MfFHK1+DG4Y6IZw root@nixos";
-    authorizedKeys = masterKeys;
+    # Step 1 (issue #270): additively trust the per-device bastion keys alongside
+    # today's fleet trust. Narrowing to bastionDeviceKeys-only happens in Step 4.
+    authorizedKeys = masterKeys ++ bastionDeviceKeys;
     sudoPasswordless = true;
     syncthingDeviceId = "YQV3LUJ-MDJZYGB-7S7G3EM-DG6JFRV-SMBEGXH-OM2YYHE-63YVDT7-EE5YMAI";
     localIp = "192.168.1.29";

--- a/hosts.nix
+++ b/hosts.nix
@@ -27,22 +27,24 @@ let
   # the doc1 stepping-stone. See issue #270.
   fleetKeys = [fleetIdentity];
 
-  masterKeys = [
-    fleetIdentity
-    # Manual Keys
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJnFw/zW4X+1pV2yWXQwaFtZ23K5qquglAEmbbqvLe5g root@pihole"
-    # Termux on Galaxy A55 — separate identity, revocable if phone is lost
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHmUU7BKMmjF53n0uCOg1w6uRe1erG13nembAiIE8ybN phone-fleet@s-a55"
-  ];
+  # Phone (Termux on Galaxy A55) — separate identity, revocable if lost. Reaches
+  # the doc1 bastion only; never a sibling. (Old root@pihole key dropped in #270.)
+  phoneKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHmUU7BKMmjF53n0uCOg1w6uRe1erG13nembAiIE8ybN phone-fleet@s-a55";
 
   # doc1 bastion entry keys — per-device, passphrase-protected, also on GitHub.
   # Authorized on doc1 ONLY (the bastion's front door); siblings never trust these.
-  # The `from=` tailnet+LAN belt + doc1 narrowing land in Step 4. See issue #270.
   bastionDeviceKeys = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBl/6XgvT5NLe1R0Yu0Lduy/4nYnyDgAufGFppUJfUom abl030@epimetheus-bastion"
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPyOTF8UNEwGkxNpzcdetGGShyX6aAG3BBk/8jLeCg11 abl030@framework-bastion"
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEmXjAlxENRxMQ1qmw/K5nsLiHLFByywTqQdotRAye79 abl030@wsl-bastion"
   ];
+
+  # doc1's front door trusts ONLY these: the per-device entry keys + the phone,
+  # each pinned with from= so a key only works from inside the tailnet or home
+  # LAN — never the open internet. No fleet key / pihole inbound. The passphrase
+  # on each key is the real gate; from= bounds where it can be presented. #270.
+  bastionFrom = ''from="100.64.0.0/10,192.168.1.0/24"'';
+  bastionKeys = map (k: "${bastionFrom} ${k}") (bastionDeviceKeys ++ [phoneKey]);
 in {
   epimetheus = {
     configurationFile = ./hosts/epi/configuration.nix;
@@ -114,9 +116,10 @@ in {
     sshAlias = "doc1";
     sshKeyName = "ssh_key_abl030";
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOJrhodI7gb1zaitbZayGHtpc+CO3MfFHK1+DG4Y6IZw root@nixos";
-    # Step 1 (issue #270): additively trust the per-device bastion keys alongside
-    # today's fleet trust. Narrowing to bastionDeviceKeys-only happens in Step 4.
-    authorizedKeys = masterKeys ++ bastionDeviceKeys;
+    # Step 4 (#270): doc1's front door = bastion keys ONLY (per-device entry keys
+    # + phone, each from=-pinned to tailnet/LAN). No fleet/pihole inbound; the
+    # fleet key it HOLDS (deployIdentity) is for reaching siblings, not entering.
+    authorizedKeys = bastionKeys;
     sudoPasswordless = true;
     syncthingDeviceId = "YQV3LUJ-MDJZYGB-7S7G3EM-DG6JFRV-SMBEGXH-OM2YYHE-63YVDT7-EE5YMAI";
     localIp = "192.168.1.29";
@@ -155,7 +158,7 @@ in {
   # SANDBOX VM - Isolated development environment for Claude Code
   # =============================================================
   # Security Model:
-  # - Fleet machines CAN SSH in (via masterKeys in authorizedKeys)
+  # - Fleet machines CAN SSH in (via fleetKeys in authorizedKeys)
   # - NO fleet identity key deployed (cannot SSH to other fleet hosts)
   # - Firewall blocks local network (192.168.x.x, 10.x.x.x, 172.16.x.x)
   # - Internet access allowed (for Claude Code, packages, etc.)

--- a/hosts.nix
+++ b/hosts.nix
@@ -16,9 +16,19 @@
 #      $ cat /etc/ssh/ssh_host_ed25519_key.pub
 #
 let
+  # The single fleet identity. Its PRIVATE half lives ONLY on the doc1 bastion
+  # (deployIdentity = true there, false everywhere else — see modules/nixos/
+  # services/ssh/default.nix). Every non-bastion host trusts it so doc1 can
+  # reach them; no sibling holds it, so a popped sibling can't move laterally.
+  fleetIdentity = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDGR7mbMKs8alVN4K1ynvqT5K3KcXdeqlV77QQS0K1qy master-fleet-identity";
+
+  # What every non-bastion (sibling) host trusts: the bastion's resident key
+  # only. Phone + pihole keys deliberately excluded here — reach siblings via
+  # the doc1 stepping-stone. See issue #270.
+  fleetKeys = [fleetIdentity];
+
   masterKeys = [
-    # Master Fleet Identity
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDGR7mbMKs8alVN4K1ynvqT5K3KcXdeqlV77QQS0K1qy master-fleet-identity"
+    fleetIdentity
     # Manual Keys
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJnFw/zW4X+1pV2yWXQwaFtZ23K5qquglAEmbbqvLe5g root@pihole"
     # Termux on Galaxy A55 — separate identity, revocable if phone is lost
@@ -43,7 +53,7 @@ in {
     sshAlias = "epi";
     sshKeyName = "ssh_key_abl030";
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGuTUS6W9BBOpoDWU7f1jUtlA3B1niCfEtuutfIKPYdr";
-    authorizedKeys = masterKeys;
+    authorizedKeys = fleetKeys;
     syncthingDeviceId = "ZUEV7QP-JVG3ZE3-UIVJBSW-RMJ55TN-ZJRBGBX-5442PJS-3A2SMMI-RU7NAAX";
   };
 
@@ -55,7 +65,7 @@ in {
     sshAlias = "cad";
     sshKeyName = "ssh_key_abl030";
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGfVo+vSFpz+oRQqC+ZbGgDzJMRlmydMidZISurihzTZ";
-    authorizedKeys = masterKeys;
+    authorizedKeys = fleetKeys;
   };
 
   framework = {
@@ -67,7 +77,7 @@ in {
     sshAlias = "fra";
     sshKeyName = "ssh_key_abl030";
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP0atvH47232nLwq1b4P7583cj+WGJYHU4vx/4lgtNgl";
-    authorizedKeys = masterKeys;
+    authorizedKeys = fleetKeys;
     syncthingDeviceId = "Z4IPNF4-564WG7C-IYNIPPN-WSQHH74-RCBMJV3-KIJ3PJT-KS4HBF3-JVDPWAY";
   };
 
@@ -86,7 +96,7 @@ in {
     sshHostName = "laptop-btibh4ie"; # Windows host MagicDNS name (Tailscale IP 100.75.246.114)
     sshKeyName = "ssh_key_abl030";
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJFKj3zCDzBVEYSUTyCN4QIDU5S8uUP/NdPi0T8wk0HF root@wsl"; # <--- PASTE HERE
-    authorizedKeys = masterKeys;
+    authorizedKeys = fleetKeys;
     sudoPasswordless = true;
     syncthingDeviceId = "5HJSG3P-3LHIT3B-77EMHZP-FIOUOSN-FULX6IU-BQBGLNZ-UUJKAJM-Q67CHA2";
     # Windows host LAN IP at the Cullen office. Cloudflare A records for
@@ -124,7 +134,7 @@ in {
     sshAlias = "igp";
     sshKeyName = "ssh_key_abl030";
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPucrnfLpTjCzItnNPvGJ0iqQs2+iTyTXZH5pCBpuvDp root@nixos";
-    authorizedKeys = masterKeys;
+    authorizedKeys = fleetKeys;
     syncthingDeviceId = "IJ3FS4G-DBM47AW-WEEM7W3-VCEOYP4-K6QRJLG-LHRZMJH-EMNN4IS-ZVHX6QF";
   };
 
@@ -137,7 +147,7 @@ in {
     sshAlias = "dev";
     sshKeyName = "ssh_key_abl030";
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILAmI3odA5l/E+hAN0W9CyIrXupYGOevMdqSyladVqsX";
-    authorizedKeys = masterKeys;
+    authorizedKeys = fleetKeys;
     syncthingDeviceId = "SDQORDI-5A2PG3X-PUXSXH6-EKSB3XD-H3S23CP-OX3PMSK-BBPYEGU-XGZWBQJ";
   };
 
@@ -163,7 +173,7 @@ in {
     # The homelab.ssh.deployIdentity = false in configuration.nix handles this
     initialHashedPassword = "$6$58mDYkJdHY9JTiTU$whCjz4eG3T9jPajUIlhqqBJ9qzqZM7xY91ylSy.WC2MkR.ckExn0aNRMM0XNX1LKxIXL/VJe/3.oizq2S6cvA0"; # temp123
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHg+0cl2eSRJP0uMoScnKY9J6ZvYERwjc843qO2BNqfB";
-    authorizedKeys = masterKeys; # Fleet CAN access this VM
+    authorizedKeys = fleetKeys; # Fleet CAN access this VM
   };
 
   doc2 = {
@@ -175,7 +185,7 @@ in {
     sshAlias = "doc2";
     sshKeyName = "ssh_key_abl030";
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPv9MVIv00FafaGR/mPE3nW565bycshuwxlh3vhT+bZp";
-    authorizedKeys = masterKeys;
+    authorizedKeys = fleetKeys;
     sudoPasswordless = true; # temporary — lock down once appliance is stable
     localIp = "192.168.1.35";
     gotifyServer = true;
@@ -191,7 +201,7 @@ in {
     sshKeyName = "ssh_key_abl030";
     initialHashedPassword = "$6$58mDYkJdHY9JTiTU$whCjz4eG3T9jPajUIlhqqBJ9qzqZM7xY91ylSy.WC2MkR.ckExn0aNRMM0XNX1LKxIXL/VJe/3.oizq2S6cvA0"; # temp123
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHYh5BYMlU8u7RGjChPe7QON+adENp+SUtg2+HYAV9FD";
-    authorizedKeys = masterKeys;
+    authorizedKeys = fleetKeys;
     syncthingDeviceId = "VFUAMOE-ID4MCL2-KQZX22M-BUCYDOM-KSHMW2Y-XYYBJI4-2FD77RH-RPGOOAJ";
   };
 }

--- a/hosts/proxmox-vm/configuration.nix
+++ b/hosts/proxmox-vm/configuration.nix
@@ -15,10 +15,10 @@
       mumNfs.enable = true;
       fuse.enable = true;
     };
-    # Base.nix enables ssh=true/secure=true.
-    # We override secure to false here matching your previous config.
-    # (Step 4 of #270 flips this to true — bastion front door is key-only.)
-    ssh.secure = false;
+    # Bastion front door is key-only (#270 step 4): no password auth, no root
+    # login. Entry is via the from=-pinned bastionKeys only. Break-glass if ever
+    # locked out: Proxmox console on prom (console login is unaffected by this).
+    ssh.secure = true;
 
     # doc1 is the bastion: the ONLY host that holds the fleet identity private
     # key (deployIdentity defaults to false everywhere else now). This is what

--- a/hosts/proxmox-vm/configuration.nix
+++ b/hosts/proxmox-vm/configuration.nix
@@ -17,7 +17,13 @@
     };
     # Base.nix enables ssh=true/secure=true.
     # We override secure to false here matching your previous config.
+    # (Step 4 of #270 flips this to true — bastion front door is key-only.)
     ssh.secure = false;
+
+    # doc1 is the bastion: the ONLY host that holds the fleet identity private
+    # key (deployIdentity defaults to false everywhere else now). This is what
+    # lets doc1 reach the keyless siblings. See issue #270.
+    ssh.deployIdentity = true;
 
     # Base.nix enables tailscale=true.
 

--- a/modules/nixos/services/gwm-archiver.nix
+++ b/modules/nixos/services/gwm-archiver.nix
@@ -55,30 +55,30 @@
   tc = cfg.triggerConvert;
 
   # When a new issue lands, wake the conversion host (WOL, LAN broadcast) and
-  # kick its marker-convert unit over SSH. The unit runs as root, so SSH uses
-  # /root/.ssh (master key → abl030@<host> works). Polkit on the convert host
-  # lets abl030 start that one unit without sudo. Fire-and-forget: --no-block
-  # returns immediately, the convert host owns the rest (convert + Komga
-  # rescan). Best-effort throughout — a failed wake never fails the unit; the
-  # convert host's weekly RTC-wake timer is the safety net.
+  # kick its marker-convert unit over SSH. The unit runs as root, so SSH uses a
+  # DEDICATED key (#270): doc2 is keyless and no longer carries the fleet
+  # identity. epi's authorized_keys (marker-convert.nix) forces this key to ONLY
+  # `systemctl start --no-block marker-convert.service` and nothing else, so a
+  # *successful connection IS the trigger* — probe and fire collapse into one
+  # (running it twice is harmless: starting an active oneshot is a no-op). Polkit
+  # on the convert host grants abl030 that one start. Best-effort throughout — a
+  # failed wake never fails the unit; the weekly RTC-wake timer is the safety net.
   triggerConvertSnippet = lib.optionalString tc.enable ''
     echo "waking + triggering convert host (${tc.sshTarget})"
     ${pkgs.wakeonlan}/bin/wakeonlan -i ${tc.broadcast} ${tc.mac} >/dev/null 2>&1 || true
-    # epi resumes from suspend-to-RAM + tailscale reconnect takes a few s.
-    up=0
+    # epi resumes from suspend-to-RAM + tailscale reconnect takes a few s; retry
+    # the forced-command SSH until it lands (each success fires marker-convert).
+    triggered=0
     for _ in $(seq 1 30); do
-      if ${pkgs.openssh}/bin/ssh -o BatchMode=yes -o ConnectTimeout=5 \
-           -o StrictHostKeyChecking=accept-new ${tc.sshTarget} true 2>/dev/null; then
-        up=1; break
+      if ${pkgs.openssh}/bin/ssh -i ${config.sops.secrets."gwm-trigger/key".path} \
+           -o IdentitiesOnly=yes -o BatchMode=yes -o ConnectTimeout=5 \
+           -o StrictHostKeyChecking=accept-new ${tc.sshTarget} 2>/dev/null; then
+        triggered=1; break
       fi
       sleep 5
     done
-    if [ "$up" = 1 ]; then
-      ${pkgs.openssh}/bin/ssh -o BatchMode=yes -o ConnectTimeout=10 \
-        -o StrictHostKeyChecking=accept-new ${tc.sshTarget} \
-        'systemctl start --no-block marker-convert.service' \
-        && echo "marker-convert triggered" \
-        || echo "WARN: marker-convert trigger failed (weekly RTC timer will catch up)" >&2
+    if [ "$triggered" = 1 ]; then
+      echo "marker-convert triggered"
     else
       echo "WARN: convert host unreachable after WOL; weekly RTC timer will catch up" >&2
     fi
@@ -198,6 +198,19 @@ in {
       format = "dotenv";
       mode = "0400";
       owner = cfg.user;
+    };
+
+    # Dedicated convert-trigger SSH key (#270), only where the trigger runs.
+    # doc2 is keyless, so the marker-convert trigger to epi can't ride the fleet
+    # identity any more. Root-owned because the notify-success unit (which fires
+    # the trigger) runs as root. The matching public half is forced-command-
+    # locked on epi in marker-convert.nix; private half is doc2-only sops.
+    sops.secrets."gwm-trigger/key" = lib.mkIf tc.enable {
+      sopsFile = config.homelab.secrets.sopsFile "gwm-trigger-key";
+      format = "binary";
+      owner = "root";
+      group = "root";
+      mode = "0400";
     };
 
     # Notification units run as root (no User=) so they can read the

--- a/modules/nixos/services/marker-convert.nix
+++ b/modules/nixos/services/marker-convert.nix
@@ -270,5 +270,16 @@ in {
         }
       });
     '';
+
+    # Authorize doc2's gwm-archiver convert-trigger key (#270). doc2 is keyless
+    # and can no longer reach here with the fleet identity, so the trigger uses a
+    # dedicated key — forced-command-locked to ONLY start this one unit, source-
+    # pinned to the tailnet/home-LAN, and `restrict` strips pty/forwarding/etc.
+    # The polkit rule above grants ${cfg.user} the actual start. A leak of this
+    # key buys an attacker nothing but "start an EPUB conversion". Private half:
+    # secrets/hosts/doc2/gwm-trigger-key. See modules/nixos/services/gwm-archiver.nix.
+    users.users.${cfg.user}.openssh.authorizedKeys.keys = [
+      ''command="${config.systemd.package}/bin/systemctl start --no-block marker-convert.service",restrict,from="100.64.0.0/10,192.168.1.0/24" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIHHE8jIJh0ZV4ROWQRYHCmcLuBUQPSDM0kKzDAt6c/2 gwm-convert-trigger@doc2''
+    ];
   };
 }

--- a/modules/nixos/services/ssh/default.nix
+++ b/modules/nixos/services/ssh/default.nix
@@ -22,8 +22,11 @@ in {
     };
     deployIdentity = lib.mkOption {
       type = lib.types.bool;
-      default = true;
-      description = "If true, deploy the fleet identity key from SOPS secrets. Set false for isolated/sandbox VMs.";
+      # Keyless by default (#270): the fleet identity private key lives ONLY on
+      # the doc1 bastion, which sets this true. Every other host stays false so
+      # a popped sibling holds no fleet-trusted key and can't move laterally.
+      default = false;
+      description = "If true, deploy the fleet identity key from SOPS secrets. ONLY the doc1 bastion should set this; siblings stay keyless (see issue #270).";
     };
     identitySecretName = lib.mkOption {
       type = lib.types.str;
@@ -75,6 +78,14 @@ in {
       path = "${homeDirectory}/.ssh/id_ed25519"; # Dynamically set path to the correct home
       mode = "0600";
     };
+
+    # On keyless (non-bastion) hosts, assert the fleet key is GONE from root's
+    # ~/.ssh. The old rootFleetIdentity mirror (removed in #270 step 2a) may have
+    # left a real copy behind; sops-nix only cleans the user-key symlink it
+    # manages, not this. Idempotent `r` — no-op where already absent. See #270.
+    systemd.tmpfiles.rules = lib.mkIf (!cfg.deployIdentity) [
+      "r /root/.ssh/id_ed25519 - - - -"
+    ];
 
     # (Former 3b/3c removed in #270.) root no longer needs the fleet key
     # mirrored into /root/.ssh, and no longer routes github.com through it:

--- a/modules/nixos/services/ssh/default.nix
+++ b/modules/nixos/services/ssh/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   config,
+  pkgs,
   allHosts,
   hostname,
   ...
@@ -79,13 +80,23 @@ in {
       mode = "0600";
     };
 
-    # On keyless (non-bastion) hosts, assert the fleet key is GONE from root's
-    # ~/.ssh. The old rootFleetIdentity mirror (removed in #270 step 2a) may have
-    # left a real copy behind; sops-nix only cleans the user-key symlink it
-    # manages, not this. Idempotent `r` — no-op where already absent. See #270.
-    systemd.tmpfiles.rules = lib.mkIf (!cfg.deployIdentity) [
-      "r /root/.ssh/id_ed25519 - - - -"
-    ];
+    # On keyless (non-bastion) hosts, assert NO fleet identity lingers anywhere.
+    # Two distinct remnants from the keyed era (#270):
+    #   1. /root/.ssh/id_ed25519 — a REAL copy the old rootFleetIdentity mirror
+    #      (removed in step 2a) installed. rm -f unconditionally; root never
+    #      holds a legitimate id_ed25519 on a keyless host.
+    #   2. ${homeDirectory}/.ssh/id_ed25519 — a sops symlink whose TARGET sops
+    #      removes when deployIdentity flips off, but it leaves the dangling
+    #      link behind. Drop it ONLY if it is a broken symlink, so we never
+    #      delete a real personal key a user might place there later.
+    system.activationScripts.purgeFleetKeyOnKeylessHost = lib.mkIf (!cfg.deployIdentity) {
+      deps = ["setupSecrets" "users"];
+      text = ''
+        ${pkgs.coreutils}/bin/rm -f /root/.ssh/id_ed25519
+        u="${homeDirectory}/.ssh/id_ed25519"
+        if [ -L "$u" ] && [ ! -e "$u" ]; then ${pkgs.coreutils}/bin/rm -f "$u"; fi
+      '';
+    };
 
     # (Former 3b/3c removed in #270.) root no longer needs the fleet key
     # mirrored into /root/.ssh, and no longer routes github.com through it:

--- a/modules/nixos/services/ssh/default.nix
+++ b/modules/nixos/services/ssh/default.nix
@@ -44,6 +44,13 @@ in {
       # Be careful here. You can lock yourself out of a host if tailscale is down.
       openFirewall = true;
 
+      # Authorization is 100% declarative from hosts.nix (#270). sshd reads ONLY
+      # /etc/ssh/authorized_keys.d/%u (rendered from authorizedKeys), NEVER the
+      # hand-editable ~/.ssh/authorized_keys — which on several hosts (incl. the
+      # doc1 bastion) held stray personal/legacy/unknown keys that bypassed the
+      # whole key model. Closing that surface is what actually locks the door.
+      authorizedKeysInHomedir = false;
+
       # We bind to 0.0.0.0 as it is only used for proxyjump and we are fine to bind to all IPS.
       listenAddresses = [
         {

--- a/modules/nixos/services/ssh/default.nix
+++ b/modules/nixos/services/ssh/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   config,
-  pkgs,
   allHosts,
   hostname,
   ...
@@ -77,38 +76,16 @@ in {
       mode = "0600";
     };
 
-    # 3b. Mirror the fleet identity into root's ~/.ssh so `nixos-rebuild`
-    # (which runs as root during auto-upgrade) can fetch `git+ssh://` flake
-    # inputs like vinsight-mcp. See issue #210 and
-    # docs/wiki/infrastructure/github-pat-and-private-inputs.md.
-    system.activationScripts.rootFleetIdentity = lib.mkIf cfg.deployIdentity {
-      deps = ["setupSecrets" "users"];
-      text = ''
-        src="${homeDirectory}/.ssh/id_ed25519"
-        if [ -r "$src" ]; then
-          ${pkgs.coreutils}/bin/install -d -m 0700 -o root -g root /root/.ssh
-          ${pkgs.coreutils}/bin/install -m 0400 -o root -g root "$src" /root/.ssh/id_ed25519
-        fi
-      '';
-    };
-
-    # 3c. System-wide SSH client config: route github.com through the fleet
-    # identity — but ONLY for root, so regular users' `git push` continues to
-    # work with their own ~/.ssh/config (or default identity handling).
-    # Pin algorithms and disable agent/pubkey fallback so a misplaced agent
-    # socket or stray key can't authenticate as someone else.
-    programs.ssh.extraConfig = lib.mkIf cfg.deployIdentity ''
-      Match User root Host github.com
-        User git
-        IdentityFile /root/.ssh/id_ed25519
-        IdentitiesOnly yes
-        HostKeyAlgorithms ssh-ed25519
-        PubkeyAcceptedAlgorithms ssh-ed25519
-    '';
+    # (Former 3b/3c removed in #270.) root no longer needs the fleet key
+    # mirrored into /root/.ssh, and no longer routes github.com through it:
+    # the last `git+ssh://` flake input (vinsight-mcp) now fetches via
+    # github: + the nix-netrc PAT, so no fleet host SSHes to GitHub for flake
+    # inputs. This is what lets siblings drop the fleet key entirely
+    # (deployIdentity = false). See issue #270.
 
     # 4. Declarative Known Hosts
     # Automatically trust all other hosts in the fleet defined in hosts.nix
-    # plus GitHub (pinned so `git+ssh://` fetches never TOFU).
+    # plus GitHub (pinned so SSH `git push` to github.com never TOFUs).
     programs.ssh.knownHosts = let
       # Filter to find other hosts that have a valid public key
       otherHostsWithKeys =

--- a/modules/nixos/services/ssh/default.nix
+++ b/modules/nixos/services/ssh/default.nix
@@ -143,6 +143,10 @@ in {
       # GitHub's documented SSH host keys — see
       # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
       # Update if GitHub rotates (rare; last rotation 2023-03-24 for RSA).
+      # Pinned UNCONDITIONALLY (#270): it was formerly gated behind deployIdentity
+      # because only the git+ssh-fetching root needed it, but that fetch moved to
+      # HTTPS+PAT. Keyless siblings still benefit — interactive `git push` over
+      # SSH to github.com stays pinned (no TOFU) instead of silently un-pinned.
       githubKnownHosts = {
         "github.com-ed25519" = {
           hostNames = ["github.com"];
@@ -150,6 +154,6 @@ in {
         };
       };
     in
-      fleetKnownHosts // (lib.optionalAttrs cfg.deployIdentity githubKnownHosts);
+      fleetKnownHosts // githubKnownHosts;
   };
 }

--- a/modules/nixos/services/ssh/default.nix
+++ b/modules/nixos/services/ssh/default.nix
@@ -1,3 +1,6 @@
+# homelab.ssh — fleet SSH server + trust. The doc1 bastion model (keyless
+# siblings, declarative auth, deployIdentity) is documented in
+# docs/wiki/infrastructure/ssh-bastion-model.md. See issue #270.
 {
   lib,
   config,

--- a/secrets/.sops.yaml
+++ b/secrets/.sops.yaml
@@ -16,6 +16,15 @@ creation_rules:
           - age1d30ye2h5pm4y8fukm3hycsedln4hg6s9tmlmxernck8vfk2mdvnq99afq3 # Master Fleet Identity
           - age1w09y86s3rtp8f06rfrwx865p9nrxsklhlsf03qsqmrlpcudleplq26xujh # doc2
 
+  # gwm-archiver convert-trigger SSH private key: doc2-only (least privilege).
+  # Forced-command-locked on epi (marker-convert.nix) to ONLY start
+  # marker-convert.service — worthless to an attacker even if it leaks. See #270.
+  - path_regex: hosts/doc2/gwm-trigger-key$
+    key_groups:
+      - age:
+          - age1d30ye2h5pm4y8fukm3hycsedln4hg6s9tmlmxernck8vfk2mdvnq99afq3 # Master Fleet Identity
+          - age1w09y86s3rtp8f06rfrwx865p9nrxsklhlsf03qsqmrlpcudleplq26xujh # doc2
+
   - path_regex: .*
     key_groups:
       - age:

--- a/secrets/hosts/doc2/gwm-trigger-key
+++ b/secrets/hosts/doc2/gwm-trigger-key
@@ -1,0 +1,18 @@
+{
+	"data": "ENC[AES256_GCM,data:YNXbLvp9aYJV6xdYbz1fGl3cU97XMiPpODgTQtkPOFcMi6yLELC9peuPIGhSsz/d/Woy1wGVnSm0HoSTCUOKxNXDXFXqvlpHdEPn3qnvl+1HlWye7e0molk/vX+HGjYs736nM9o9yhy5ijieN2TIoyrn/oSFsVD34RbMi3Utc68JeVyJMITXODYYyAqyFWOe0zS2IkXPBYPpNlkv7K5LQqI57hbs01T5K9tVoYbI2qmrh45huTNqbd4dSNgA1uOP2y75yTS+J/VjU7W0dClYht+6vJcRJ0mTIFOzB+uBKpL4ek/yjt2bWfC6JsKExM7XArsekJUzXQxdezO0Dwbin+PIQaJ/gBz8oEkT4LTn0jjcOREQW7lwZD6b/pmwX8NmQljgA+Eox8y4FOzJen91mB0VFOb6AVDKiFYmXxD5O2BZKDT17nO+/QOdjsvrRogDIowQGIRIULz0HBwGZIdXrapz+LCYgQyAjfIfnw5vz0iY0Kk5DrU8WwE/82lq7xVfVum+8ku5MBuz/QzhsN9Q9nFQK9clQ/p+Lo5vX5X7eAyudx0=,iv:gQUwptGLfdLl3EGbKmKu7SYxbbxcLSN3Yp6G+QeiLOc=,tag:BPTX9XzKkq662jZFY8omng==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4ZC9ZTFJ1K2NJN2xmSVdF\nQnBVMnpHblFEYzhVSlhuUHdwaWFhdmg2RmlRCkh2WlNobTRFNnhkREgyZDFUR0pZ\nUkJuVzFIUkp5SUJ3dGJ1TTVOYlI3WEkKLS0tIE96cDJ3Y250N1NxaHlXck5XK3Vr\nZTJnTXBMWno3TUtjbzRuTjlCK0hIbEEKfkCwgTT+sEXAjN+CWLSL2EZy8imGZnYX\n/P90QmP6RxHOwD7qRBxFOk8nmWF4Uukhqryy/+h66drTRbGtdElRUA==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1d30ye2h5pm4y8fukm3hycsedln4hg6s9tmlmxernck8vfk2mdvnq99afq3"
+			},
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzU3pFSVZmb043M1hNR1Ri\nZEdSZ1Z0SzVycTFsUDlYTVlwOVY5ajZzeFcwCmRsUnBadWhCallqK1JXRU9rbnA1\nOWpGOCt4ZzVubTVOaEMyc2xUR0dwNncKLS0tIDJuMHdCYjgrWHZWMHpjUzBINlNJ\nNUlKam1uenpVNHkwRFRLeE84UUVsQmMKzgt2JJo8/t3lnbts+JkQRDkhxwUer3Pb\nk49EteX02DhLCOGIJdqcVPj9jjt4h89U4QSqNpE+r8ivucOifW5Wlw==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1w09y86s3rtp8f06rfrwx865p9nrxsklhlsf03qsqmrlpcudleplq26xujh"
+			}
+		],
+		"lastmodified": "2026-06-08T06:38:23Z",
+		"mac": "ENC[AES256_GCM,data:JScVrKW7SUxuINsArGqeZH5SbnVdADnQdx+Dtf+OqwWlTpJis5TJ3Dsz/zltIme3HE1/jfelY8r23CZ1cR9itF+gp6OHJnu243Mb6+WEVZLonMz6aZ9TQsbImGk25bl8ChdTEO/r4sHknA9cRIZ5/PlulNFR5hS8EIhoHdPt8w4=,iv:bS/vSQ+vZsX6CUpBO3MkWIEKzE1ghHi8qvEqwpMoHRE=,tag:YGF1Ez7jwbUQ7qZRQxT1bA==,type:str]",
+		"version": "3.13.1"
+	}
+}

--- a/secrets/nix-netrc
+++ b/secrets/nix-netrc
@@ -1,59 +1,59 @@
 {
-	"data": "ENC[AES256_GCM,data:Z9J2xjNTTlEfg2Yg5sPFDvDYcCmW184XFPq3b1JSHAGZIMnXUbeQ67QZ7Cm4tS8pS+ISm9d0GXUsX2/+eWYDOTYnEoqtRP8ZJJDxbXjfjoQ4GwfDBLMFCKd6/t226YyvN50gA57Sq+qaHSpnSPjfeI1nRDry7Hsx0pKOv5zdhdQoiq0pUtVsFOdZmzZuK/jSEJoDIlHUzFkiTslqpB0jKg==,iv:xOZXS61SSud8BGw3q3U8QI9CniJEJq3QBDXmvxiEqEY=,tag:lhuyyYeWnPMcEsAJptpZNg==,type:str]",
+	"data": "ENC[AES256_GCM,data:TBnkbszwsUBRXbMJxRz7Dm/nZI95Gt8GQd5+N1/6DCCWerDYEwErN7lVv5mauqXbEcehBKjurTiml8XLso6QeIwQv+uctNg5PiGHtl4EXaD+ZEOJEHqQnMJgTQjgMZtaSMfaaDbMUeuLXKfBZSGmL43eWo+Un20G5zEH8iMXDTD3OXCoJd/+Lle/LZsV8Coe6m3NiHnn/aSb0S4ZXLiYt2tUvIidfns3ZpwCIUurpttCT7lYH7Ybs/aqOwp7pht6LKxmkq+iR4Xa0Xt1j+SXAfj8WLiqG5YnxdT9ixKH4z3kuMhttSokutoLD6s8Vclj5559qwKr88cgyPPO8OTFcNg9gwJvk93hlg==,iv:/a6BDwpoIX+SMEWQd8L+dexqBNRxprAou+Gcsr1Xprk=,tag:xRzSYFn4PU6bPGWi1rUUpQ==,type:str]",
 	"sops": {
 		"age": [
 			{
-				"recipient": "age1y4sdqs8dnlrma395hjna6dmzcctaeqpr8rh0wx6ap626uv0mremqsgdn30",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaVzAyV1lpaHVPVlZQVytZ\ndi9OYTdoYVZqVVBZTkhSSjB5QlJXQ3lQZFZBCnh1dnphRVowYTNScWM1bU9iYlFp\nUDJoRUJjV2wzSWZJcDg5ak14NDQ0V1EKLS0tIE45RUkzS1ZEajdIaCtQbnlxMDh4\nbTQvZms3YmRXUDBnbVV0cHN2T3NOd2sKbQtjCWTmEyGGAy8MfudUCefmzKl8/D4/\na88V2V/kPQGTJEq2LiBYy0gCjG9L+KTQbc0zz46bwK/gprVJDZs7qw==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaVzAyV1lpaHVPVlZQVytZ\ndi9OYTdoYVZqVVBZTkhSSjB5QlJXQ3lQZFZBCnh1dnphRVowYTNScWM1bU9iYlFp\nUDJoRUJjV2wzSWZJcDg5ak14NDQ0V1EKLS0tIE45RUkzS1ZEajdIaCtQbnlxMDh4\nbTQvZms3YmRXUDBnbVV0cHN2T3NOd2sKbQtjCWTmEyGGAy8MfudUCefmzKl8/D4/\na88V2V/kPQGTJEq2LiBYy0gCjG9L+KTQbc0zz46bwK/gprVJDZs7qw==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1y4sdqs8dnlrma395hjna6dmzcctaeqpr8rh0wx6ap626uv0mremqsgdn30"
 			},
 			{
-				"recipient": "age1wnxnwrzz506s9jw0hg5tptx7s4ujm7gja3wj5nerpll7cak4guxs4td3z0",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2Z282QnJGK1RZNGdlYlhY\ncmVKU0NFZVNnVXJnYzBsVUNXSjNpUWR3U2h3CjJtRzBXSmEwcC9jM2NyY0hEbWEv\nSkRWTkhERm9MYnF0M3lEM3RJbG1PQVUKLS0tIDBBMFo2WW1wVmVRelBqYkorM0FC\nZmhFWHBpMnM4MGlZL3hWM2Z2S201czQKft/CoCgStlrIU9ujV4OPdWLSc0FzCgZu\nF31JbU4zGB/c9ayoC1S3JN37CUdBGAWhq+8UUAajKAvFMoykF1By8Q==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2Z282QnJGK1RZNGdlYlhY\ncmVKU0NFZVNnVXJnYzBsVUNXSjNpUWR3U2h3CjJtRzBXSmEwcC9jM2NyY0hEbWEv\nSkRWTkhERm9MYnF0M3lEM3RJbG1PQVUKLS0tIDBBMFo2WW1wVmVRelBqYkorM0FC\nZmhFWHBpMnM4MGlZL3hWM2Z2S201czQKft/CoCgStlrIU9ujV4OPdWLSc0FzCgZu\nF31JbU4zGB/c9ayoC1S3JN37CUdBGAWhq+8UUAajKAvFMoykF1By8Q==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1wnxnwrzz506s9jw0hg5tptx7s4ujm7gja3wj5nerpll7cak4guxs4td3z0"
 			},
 			{
-				"recipient": "age1gr4papzzdqfxd34ushr88303f2ypdwvgx9cw2xqs87yn4zf8lpxqc0rur5",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxZnArTXR3amhzQ3JwNXl6\nSUFiYlprY3hCNWRkN0NhWTliQlJZWWJKT3kwCktYSjNUV2dPUGs3V0U3NTVSeXV2\nTGl2SzNLeTRNQWRlY1RVT05rOXdKNU0KLS0tIEVNQkdEQ1E3OEVXME1iUVN3MlRo\nWUlveDBRdHRpTGhKSTRIeUpvaWdGOFkKj5lEi3VauIJhjL8jUW4v9vfNE1VdRBNi\n7/ofmqWNoOV7Q4kF5ajoPad6nDYvGPZTkhihp7g4UFFJYqD3W/kwKw==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxZnArTXR3amhzQ3JwNXl6\nSUFiYlprY3hCNWRkN0NhWTliQlJZWWJKT3kwCktYSjNUV2dPUGs3V0U3NTVSeXV2\nTGl2SzNLeTRNQWRlY1RVT05rOXdKNU0KLS0tIEVNQkdEQ1E3OEVXME1iUVN3MlRo\nWUlveDBRdHRpTGhKSTRIeUpvaWdGOFkKj5lEi3VauIJhjL8jUW4v9vfNE1VdRBNi\n7/ofmqWNoOV7Q4kF5ajoPad6nDYvGPZTkhihp7g4UFFJYqD3W/kwKw==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1gr4papzzdqfxd34ushr88303f2ypdwvgx9cw2xqs87yn4zf8lpxqc0rur5"
 			},
 			{
-				"recipient": "age1d30ye2h5pm4y8fukm3hycsedln4hg6s9tmlmxernck8vfk2mdvnq99afq3",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3UXZIdERwRndjOHRqVXRQ\nZy9hT2FHTEw3YUI3Wm94N1JhZGRPckdyaWtvCmlvcUhESmhEcmNIOHB0TUxwK2ti\nL0JQanA5MDhYSnMvUWRFalhkZFkxZXMKLS0tIEprKzAzVkZaMTh5S2llSXgwWitB\nemxKdW5TWTh4akdaZU51UGtLMXVaMmcK/Kb18Uv+oj/yH+M70fn2WbuRSiX3jq1H\nCgZXv9KvyYFem31VnnQdDnMK6WTU+32zN9zuqEr7oCGJh9IqraZVgw==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3UXZIdERwRndjOHRqVXRQ\nZy9hT2FHTEw3YUI3Wm94N1JhZGRPckdyaWtvCmlvcUhESmhEcmNIOHB0TUxwK2ti\nL0JQanA5MDhYSnMvUWRFalhkZFkxZXMKLS0tIEprKzAzVkZaMTh5S2llSXgwWitB\nemxKdW5TWTh4akdaZU51UGtLMXVaMmcK/Kb18Uv+oj/yH+M70fn2WbuRSiX3jq1H\nCgZXv9KvyYFem31VnnQdDnMK6WTU+32zN9zuqEr7oCGJh9IqraZVgw==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1d30ye2h5pm4y8fukm3hycsedln4hg6s9tmlmxernck8vfk2mdvnq99afq3"
 			},
 			{
-				"recipient": "age17pejn8m9tz063y3waahgyyn365n22hzgg5hr64ey7wk79ee8ccmsh8z294",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaN2ZZaGZiVFh2SkFydTBH\nWnhuVTdpRnRqbGNsUjBVWWxtdUMrRXBZbFhjCitZZVNIVHM1ZE5TUDF4czRHQUg1\ncXJqdjdCVGtpcjcrTFZJUC81dnFKbjAKLS0tIG1RUkY4d0ZiZVdzczN0azNJaXBq\nM3JRa0lNdEtqRzV0WVU5TW8yajR6aUkK+yzCLh8dZ5oPr4qXvj4kQ/EiGceURlE3\n/LkX/Dgk7XiyRNtz/olFBLGVOQpYiT11XWbk0M0O4i3EIx2fhoR3Fw==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaN2ZZaGZiVFh2SkFydTBH\nWnhuVTdpRnRqbGNsUjBVWWxtdUMrRXBZbFhjCitZZVNIVHM1ZE5TUDF4czRHQUg1\ncXJqdjdCVGtpcjcrTFZJUC81dnFKbjAKLS0tIG1RUkY4d0ZiZVdzczN0azNJaXBq\nM3JRa0lNdEtqRzV0WVU5TW8yajR6aUkK+yzCLh8dZ5oPr4qXvj4kQ/EiGceURlE3\n/LkX/Dgk7XiyRNtz/olFBLGVOQpYiT11XWbk0M0O4i3EIx2fhoR3Fw==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age17pejn8m9tz063y3waahgyyn365n22hzgg5hr64ey7wk79ee8ccmsh8z294"
 			},
 			{
-				"recipient": "age1ysfdznu87vwwqtpudchkyx0wlhuhteqljrqkt6963pcmhwprlgcqasg0gv",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3UVRyeGhYRzlMZnZ6RGZi\nNVZpeEJKaGc3NlFPRU94STdZbDd6TGE0TWlBCm1nRHZEL1N5eVJkRmlsdFFXWjFJ\nOHlyemkxb2kwMmNYdXR4T3p3VHNodkUKLS0tIDhsUm1TR293QnBOaHREbWRSUXF6\nVk96VjhhZ2toVUR6TzJYMENhQ3kzMWcKmW7b5iZQFOt6K8L5H3API4HASlZcoGTn\nwtuSBUuYufrNEw6A/NLrsEt3VyBfdRGoS6OMRcbA/+Sce3nZo5adBQ==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3UVRyeGhYRzlMZnZ6RGZi\nNVZpeEJKaGc3NlFPRU94STdZbDd6TGE0TWlBCm1nRHZEL1N5eVJkRmlsdFFXWjFJ\nOHlyemkxb2kwMmNYdXR4T3p3VHNodkUKLS0tIDhsUm1TR293QnBOaHREbWRSUXF6\nVk96VjhhZ2toVUR6TzJYMENhQ3kzMWcKmW7b5iZQFOt6K8L5H3API4HASlZcoGTn\nwtuSBUuYufrNEw6A/NLrsEt3VyBfdRGoS6OMRcbA/+Sce3nZo5adBQ==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1ysfdznu87vwwqtpudchkyx0wlhuhteqljrqkt6963pcmhwprlgcqasg0gv"
 			},
 			{
-				"recipient": "age10hqxw3uxvg9nkc56rm495ty0rge0yhkcqp95gx00tgsv8ptg93mqwywlja",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvL1MyMjZITFhJM3pTbmN5\nenlTaUEycitmT2dxeXdhVlJqVnFIOGV5Tlg0CmNicUV0QjVVODF5cTJQN01hMnV6\nNTNNay9LU1JjNjhnTU1SNGR0bzhjY3MKLS0tIFp3NTNCdm1mZkRKd3Brb1IxRThK\ndWlHTFMzL3VyRkxQRUVMQW1OVzhGYTAKYNFBm3XeNPstrwy8F0Hvy7iL7gYMjFf2\nTMRFLEQBuLW5SeuL1kFhccxKtls4W9uaKiaSCCM3687zNwHiuFugvw==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvL1MyMjZITFhJM3pTbmN5\nenlTaUEycitmT2dxeXdhVlJqVnFIOGV5Tlg0CmNicUV0QjVVODF5cTJQN01hMnV6\nNTNNay9LU1JjNjhnTU1SNGR0bzhjY3MKLS0tIFp3NTNCdm1mZkRKd3Brb1IxRThK\ndWlHTFMzL3VyRkxQRUVMQW1OVzhGYTAKYNFBm3XeNPstrwy8F0Hvy7iL7gYMjFf2\nTMRFLEQBuLW5SeuL1kFhccxKtls4W9uaKiaSCCM3687zNwHiuFugvw==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age10hqxw3uxvg9nkc56rm495ty0rge0yhkcqp95gx00tgsv8ptg93mqwywlja"
 			},
 			{
-				"recipient": "age1tywfda7ms2v6jm22t3gvzjrck900k7ax460rg24z6unrtw7rzs6q44dyaj",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaWg3bWtmQkh6aDNxM3J4\nb1prQXBzTytkUWVYRnN3c1VQUWVJcDFOMkVFCkdjQmlPM0tlSC9kbXdOQkdBeTha\nWGJ6RkFQNUFxbGNRK2s3UUNDZ3kyNVEKLS0tIEdOR1JoQ245UnlQR0d4MzN2ZVhQ\nTGR3enBNR0JnZi9mSzdiK1l2NEFRN0EKaXWR9nbZHZz/8xJsN/E0r9iHwRCp17Hx\nWpuiPnj6M6Lqt89Fb2BaYBApebGP6tkPQfsMU69ir6RY9XYun3kl3g==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaWg3bWtmQkh6aDNxM3J4\nb1prQXBzTytkUWVYRnN3c1VQUWVJcDFOMkVFCkdjQmlPM0tlSC9kbXdOQkdBeTha\nWGJ6RkFQNUFxbGNRK2s3UUNDZ3kyNVEKLS0tIEdOR1JoQ245UnlQR0d4MzN2ZVhQ\nTGR3enBNR0JnZi9mSzdiK1l2NEFRN0EKaXWR9nbZHZz/8xJsN/E0r9iHwRCp17Hx\nWpuiPnj6M6Lqt89Fb2BaYBApebGP6tkPQfsMU69ir6RY9XYun3kl3g==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1tywfda7ms2v6jm22t3gvzjrck900k7ax460rg24z6unrtw7rzs6q44dyaj"
 			},
 			{
-				"recipient": "age1zl8mt8gp43kyr02vz4scvvmlsl6929ps59tpcuutxazthxhsvueqvmfpyg",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPTmpOK2xjQU1EajBpZUpU\nQ3paSTMyWk5JbmxOK2xSUUNCcGdvWkUzSXprClBmVllVRVdKUks4YjlkU1BybHky\nRzYwaUdTbFo2czFlNmJIWUxPcGVZdEkKLS0tIDR1amw4UUk1WVRBaGlvVXNOUFV3\nODVqTExyZW5hVHlreUZPemliSDhCYjgKFtDtqELi73RKXsZpk4rH/zV0tO3hcIYz\nTGr16bT8d0lTnQeyRcsH7gkvjyIS3bySulX7SVAqEEFRbMyKOCvWzw==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPTmpOK2xjQU1EajBpZUpU\nQ3paSTMyWk5JbmxOK2xSUUNCcGdvWkUzSXprClBmVllVRVdKUks4YjlkU1BybHky\nRzYwaUdTbFo2czFlNmJIWUxPcGVZdEkKLS0tIDR1amw4UUk1WVRBaGlvVXNOUFV3\nODVqTExyZW5hVHlreUZPemliSDhCYjgKFtDtqELi73RKXsZpk4rH/zV0tO3hcIYz\nTGr16bT8d0lTnQeyRcsH7gkvjyIS3bySulX7SVAqEEFRbMyKOCvWzw==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1zl8mt8gp43kyr02vz4scvvmlsl6929ps59tpcuutxazthxhsvueqvmfpyg"
 			},
 			{
-				"recipient": "age1stg8x4ssjk2zn0qp3paltfdutkl77wfnph7mpastjlgw243gfycszl8mxt",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoY1VkUVZ0UzM5RXdiL2V2\nTnJJMFZaOGk2RUR3MzdWZW9oQVo0cGhoNlFrCkIrSkh4UjZhMnh2OUY5OSt1NlhB\nYlVaUDJyeWJhZmhEUjNCYTU4UytVWkUKLS0tIGlNNHVzaVFlVWlxY2IxZXFEVUVT\nak5lT2ZmZ1lIVjVTakJVa3NEb00rMUkKBEz6caQzmtZAP3cfozV8zidYlfpiZXer\n2zQLZpRzGZLbpBNYmMtX+kPFefXGjUdD0sadgvWpZ80kSj7cqUxr5g==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoY1VkUVZ0UzM5RXdiL2V2\nTnJJMFZaOGk2RUR3MzdWZW9oQVo0cGhoNlFrCkIrSkh4UjZhMnh2OUY5OSt1NlhB\nYlVaUDJyeWJhZmhEUjNCYTU4UytVWkUKLS0tIGlNNHVzaVFlVWlxY2IxZXFEVUVT\nak5lT2ZmZ1lIVjVTakJVa3NEb00rMUkKBEz6caQzmtZAP3cfozV8zidYlfpiZXer\n2zQLZpRzGZLbpBNYmMtX+kPFefXGjUdD0sadgvWpZ80kSj7cqUxr5g==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1stg8x4ssjk2zn0qp3paltfdutkl77wfnph7mpastjlgw243gfycszl8mxt"
 			},
 			{
-				"recipient": "age1cd4wnte9ffe65ysqzvtkwu5uzvvxn9xeln7n5ctkjsk4c589fc5qkt397e",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWR1dOeVN3U0R6ZkZUM1Az\nNCtQUHZsbnNjem9rWVlZYWhTTmFUOGQ5UzMwCk5RTThUOXlVeGRPOFVOa3ZCZlVa\ncG5uMkdQVjdVK1M0Qm5vMkFreDE3bU0KLS0tIFhQZlNZaG9GNTlpc3NJV3YvcEZJ\nazlNaXV4MjZHM3QyZk9lWWRJdEpIekkKkyyt3ydTq5Dln7t2iO/L+Gg5Z4WU9urD\npewx5nJhkoi2u4SFKNxeGZ8kaE9kXGa9MvawKnB3cOwjf5N57fhITA==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWR1dOeVN3U0R6ZkZUM1Az\nNCtQUHZsbnNjem9rWVlZYWhTTmFUOGQ5UzMwCk5RTThUOXlVeGRPOFVOa3ZCZlVa\ncG5uMkdQVjdVK1M0Qm5vMkFreDE3bU0KLS0tIFhQZlNZaG9GNTlpc3NJV3YvcEZJ\nazlNaXV4MjZHM3QyZk9lWWRJdEpIekkKkyyt3ydTq5Dln7t2iO/L+Gg5Z4WU9urD\npewx5nJhkoi2u4SFKNxeGZ8kaE9kXGa9MvawKnB3cOwjf5N57fhITA==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1cd4wnte9ffe65ysqzvtkwu5uzvvxn9xeln7n5ctkjsk4c589fc5qkt397e"
 			},
 			{
-				"recipient": "age1w09y86s3rtp8f06rfrwx865p9nrxsklhlsf03qsqmrlpcudleplq26xujh",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkOEZCdE9hK0xBVk9EMWs3\nTjl0ajloNGUyMENNajgrRGZyWmlHN0E3eHljClU4QUZxcTJZemN5cW80eG9uUWtG\nRSt0SkIrUExnZlo4RFRENy9wRG9sMVEKLS0tIFk3TmFQUjhUaXNCL2dBV2huSCs4\nZGVTbzhKU2s4TXN6Tm5wQjRPaCtjdUEKNi1bmhdYrwprVu2+IHF2ZzXxb4Tui9Kh\nVS/X6a0deWerEyjctNL1LDcjK4yyGr2JnN4FG1j6LX2VlAEmjnJo4w==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkOEZCdE9hK0xBVk9EMWs3\nTjl0ajloNGUyMENNajgrRGZyWmlHN0E3eHljClU4QUZxcTJZemN5cW80eG9uUWtG\nRSt0SkIrUExnZlo4RFRENy9wRG9sMVEKLS0tIFk3TmFQUjhUaXNCL2dBV2huSCs4\nZGVTbzhKU2s4TXN6Tm5wQjRPaCtjdUEKNi1bmhdYrwprVu2+IHF2ZzXxb4Tui9Kh\nVS/X6a0deWerEyjctNL1LDcjK4yyGr2JnN4FG1j6LX2VlAEmjnJo4w==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1w09y86s3rtp8f06rfrwx865p9nrxsklhlsf03qsqmrlpcudleplq26xujh"
 			}
 		],
-		"lastmodified": "2026-03-21T23:09:34Z",
-		"mac": "ENC[AES256_GCM,data:juZNbC4B+3ASaoxfO+9pCnD5tf9IaYHdmEZlBcJFUFmVSE30RQg/OuhKPbFY4I0Ebel++q6B9TSn+xrbGBD7plj2YabdmpcLQ1g2ug6/o2uoSdp+e61MhoyXAW7PjGhoreTa9yxsCwdHqaSv8uPUgMazHL6L3jW0l3kaKtVwq+0=,iv:Z1uNXTCvfY4yKnk99CILXqOf0uBM8hkD5enx2Fefitk=,tag:vnAjK3wpnPFM0EXw/rMOcg==,type:str]",
+		"lastmodified": "2026-06-08T05:23:46Z",
+		"mac": "ENC[AES256_GCM,data:FzM1jVkdyDla8rnvfCyKdbbWj6PTrSmLmf8V0n1grVnZDubSkIoyEQUoO3li9bQZmWpeqGIsa7U3yrbrlAnvplQART2nmOqslOTLv8VvK/mIq4u5KqT3afc1aM2bvCoFfo1EJv/iRrJiAk6fC+5jhGZ4wK/ns1nbj+MXAPWvIJU=,iv:hOJpsPEgyDj6vecCzZAUT85d5fbtP6A5BzrzNNvk9JQ=,tag:kBBpaNhkpl0lBioHjgjFjQ==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.12.1"
+		"version": "3.13.1"
 	}
 }


### PR DESCRIPTION
Implements the no-infra interim from #270 (gates the full #241 CA architecture). Collapses the fleet's SSH blast radius from "one popped host = the whole fleet" down to a single hardened chokepoint.

## Before → after

**Before:** all 8 hosts deploy the *same* fleet private key to `~/.ssh/id_ed25519`, and every host authorizes it. Pop any host → read that file → it *is* the fleet skeleton key. Plus sshd honored hand-edited `~/.ssh/authorized_keys` files holding stray/unknown keys outside `hosts.nix`.

**After:**
- The fleet private key lives **only on the doc1 bastion** (`deployIdentity` now defaults false; only doc1 sets it true). Every sibling is keyless — a popped sibling holds nothing fleet-trusted and cannot move laterally (verified: `igpu → doc2` = Permission denied).
- Siblings trust **only** the bastion's resident key (`fleetKeys`). doc1 is reached with per-device **passphrase** keys + the phone, each pinned `from="100.64.0.0/10,192.168.1.0/24"`; doc1 is `secure = true` (no password auth, no root login).
- SSH authorization is **100% declarative**: `authorizedKeysInHomedir = false` → sshd reads only `/etc/ssh/authorized_keys.d/%u` rendered from `hosts.nix`. The hand-edited `~/.ssh/authorized_keys` surface (incl. 6 stray keys on the bastion itself, one unidentified) is closed.

## How the keyless model survives auto-upgrade
The only `git+ssh://` flake input (`vinsight-mcp`) was the sole reason every host needed an SSH key. Re-pointed it to `github:` so it fetches via the existing **read-only** GitHub PAT (`nix-netrc`, scoped to `vinsight-mcp` + `cellar-manager`, Contents:Read). `rootFleetIdentity` mirror + the github `Match` block are removed. Trade-off documented inline: a broken/expired PAT now breaks eval of those two private inputs fleet-wide (keep the token on a long expiry).

## Access model (stepping-stone)
Land on doc1 with `id_doc1`, reach siblings from there via doc1's resident fleet key. Claude's autonomous deploys run *on* doc1, unchanged. `phone → tmux on prom` unchanged.

## Verified
- All 9 `nixosConfigurations` eval clean at every step.
- doc1: renders 4 `from=`-pinned keys; PasswordAuthentication=false, PermitRootLogin=no, deployIdentity=true. Human login via `id_doc1` confirmed from epi/framework/wsl after lockdown.
- igpu canary: no fleet key (user husk + /root copy purged), stray file disabled, `igpu → doc2` denied, doc1 → igpu works, private+public flake fetch via RO PAT works (no public-fetch poisoning).

## Deployment notes
- Merging propagates to the fleet via the nightly `rolling-flake-update` (23:00 AWST), or via proactive `--refresh` deploys per host. doc1 + igpu already run this config from the branch.
- **doc2** goes keyless on its first post-merge rebuild (it was intentionally not deployed from the branch to avoid clobbering in-flight #239 `acl-apply` work, which lives on `feat/tailscale-acl` and is not on master).
- **#239 merge conflict warning:** this branch changed `authorizedKeys` on the `dev`/`sandbox` host blocks (`masterKeys` → `fleetKeys`); #239 *deletes* those blocks. Whoever merges #239 second resolves the `hosts.nix` conflict by taking the deletion.
- Stray `~/.ssh/authorized_keys` renamed to `.disabled-270` on doc1 + igpu; still live on **epi** (asleep) and **cache** (unreachable) until their post-merge rebuild renders `authorizedKeysInHomedir=false` (which makes sshd ignore them regardless). **caddy** is HM-only — its file is a separate management domain, left untouched.

## Post-merge TODO (tracked on #270)
- [ ] Revoke the **old broad GitHub PAT** — only after the RO token is live on every host (post-nightly), else siblings' private fetches break.
- [ ] Disable leftover stray files on epi/cache once reachable.

Break-glass throughout: Proxmox console on prom (console login is unaffected by sshd `secure=true`).