### PR TITLE
docs: #234 sweep — reconcile secret-model references fleet-wide

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -15,6 +15,11 @@
   `bastionInvariantCheck` enforces exactly one `deployIdentity=true`.
 - Full model: `docs/wiki/infrastructure/ssh-bastion-model.md`.
 
+## Secrets model (#234, 2026-06-08)
+- Per-host sops scoping + cold break-glass (Bitwarden+paper) + warm doc1 editor key;
+  "master" recipient retired (it was the fleet SSH key in age form). Re-key with
+  `sops updatekeys` from **inside `secrets/`**. See [sops-recipient-model.md](sops-recipient-model.md).
+
 ## Key Decisions
 - Custom Claude Code HM module stays over official `programs.claude-code`
 - Episodic-memory plugin disabled (npm-install breaks the Nix store)

--- a/.claude/memory/sops-recipient-model.md
+++ b/.claude/memory/sops-recipient-model.md
@@ -1,0 +1,33 @@
+---
+name: sops-recipient-model
+description: "Post-#234 sops secret model — per-host scoping, break-glass + editor keys, master retired"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 50946a58-6570-4833-96f2-140e7d93a90d
+---
+
+As of #234 (2026-06-08) `secrets/.sops.yaml` is **per-host scoped**: a file under
+`secrets/hosts/<H>/` decrypts only on host `<H>`, plus two universal keys —
+**break-glass** (cold, recovery-only, on **no host**: Bitwarden secure note +
+printed paper; pub `age1y6na…`) and **editor** (warm, doc1
+`~/.config/sops/age/keys.txt`, drives all re-keys/edits; pub `age17uw7…`).
+Multi-host rules: acme→{doc1,doc2,igpu,wsl}, uptime-kuma→{doc1,doc2,igpu};
+fleet-wide (nix-netrc/atuin-*/gotify)→all 7 live hosts; **fail-closed `.*`
+fallback** (editor+break-glass only). `sopsRecipientScopeCheck` in `flake.nix`
+enforces it. `ssh_key_abl030`, the MCP creds, and the pfSense *control* token are
+doc1-only; doc2's exporter has a separate read-only pfSense key.
+
+**There is no "master" recipient anymore** — the old "Master Fleet Identity" was
+`ssh-to-age(ssh_key_abl030)` (the fleet SSH key in age form), retired in #234.
+Don't go looking for a master key.
+
+**Why:** a popped sibling could `sops -d` every secret (incl. the fleet key),
+undermining the [[fleet-ssh-topology]] bastion at the secret layer; and there was
+no real off-box break-glass.
+
+**How to apply:** to re-key after a `.sops.yaml` change, run `sops updatekeys`
+from **inside `secrets/`** (config discovery uses CWD, not the file path) — doc1's
+editor key decrypts everything. Full model, recovery, rollback, and editor-key
+reconstruction: `docs/wiki/infrastructure/sops-break-glass-recovery.md`. dev +
+sandbox hosts were decommissioned in the same work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ The presence of `configurationFile` determines whether a host is a full NixOS sy
 
 ## Secrets Management
 
-Uses Sops-nix with Age encryption. Config: `secrets/.sops.yaml`.
+Sops-nix + Age. Config: `secrets/.sops.yaml`. **Per-host scoped (#234):** a secret under `secrets/hosts/<H>/` is decryptable only by host `<H>` plus two universal keys — a cold **break-glass** key (recovery only; Bitwarden + printed paper, on no host) and a warm **editor** key (doc1 `~/.config/sops/age/keys.txt`, used to edit/re-key from the bastion). Shared secrets get explicit multi-host/fleet-wide rules; a **fail-closed** `.*` fallback means an unscoped secret deploys nowhere until given a rule. `sopsRecipientScopeCheck` (a flake check) enforces the per-host invariant. Re-key with `sops updatekeys` run from **inside `secrets/`** (config discovery uses CWD). There is no "master" recipient — the old fleet-key-as-master was retired. Full model, recovery, and rollback: [docs/wiki/infrastructure/sops-break-glass-recovery.md](docs/wiki/infrastructure/sops-break-glass-recovery.md).
 
 ## Troubleshooting
 
@@ -283,6 +283,8 @@ These MCPs are **subagent-only** — defined in `.claude/agents/` to avoid conte
 - `pfsense` — Firewall rules, NAT, VPN, DHCP, DNS
 - `unifi` — Network devices, clients, WLANs, port profiles
 
+These agents run on **doc1**, where their credentials live. As of #234 the MCP control creds deploy to `/run/secrets/mcp/` on **doc1 only** (`homelab.mcp` defaults off fleet-wide; doc1 opts in) — they used to land on every host. doc2's metrics exporter uses a separate **read-only** pfSense key (`metrics-exporter-ro`), not the full-control token.
+
 Full HA usage guide incl. Music Assistant playback and volume quirks lives in `docs/wiki/services/` (search for `home-assistant`).
 
 ### mcp-nixos
@@ -303,11 +305,12 @@ Full HA usage guide incl. Music Assistant playback and volume quirks lives in `d
 - **proxmox-vm** (doc1): Main services VM on Proxmox prom
 - **doc2**: Secondary services VM on Proxmox prom (IPs: 192.168.1.35/ens18, 192.168.1.36/ens19). Hosts most homelab services: immich, seerr/overseerr, cratedigger, slskd, musicbrainz, discogs, paperless, mealie, kopia, uptime-kuma, etc. All state on virtiofs (`device = "containers"` from prom ZFS). Auto-updates with reboot.
 - **igpu**: Media transcoding VM on Proxmox prom with AMD iGPU passthrough
-- **dev**: Development VM on Proxmox prom
+
+*(The `dev` and `sandbox` VMs were decommissioned in #234 — removed from `hosts.nix`. Live fleet = the 7 hosts above.)*
 
 ### Hypervisors
 
-- **prom** (192.168.1.12, AMD 9950X): Proxmox host running most VMs (doc1, doc2, igpu, dev, …). Manage via the Proxmox web UI; no in-repo automation.
+- **prom** (192.168.1.12, AMD 9950X): Proxmox host running most VMs (doc1, doc2, igpu, …). Manage via the Proxmox web UI; no in-repo automation.
 - **tower** (192.168.1.2): Unraid host running NAS + some VMs + docker stacks. `ssh root@tower` works but is gated — ask the user to unlock first.
 
 ### Network & DNS Topology (non-obvious — read before debugging)

--- a/docs/plans/2026-06-08-001-refactor-sops-recipient-scoping-plan.md
+++ b/docs/plans/2026-06-08-001-refactor-sops-recipient-scoping-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "refactor(secrets): least-privilege sops recipient scoping (#234)"
 type: refactor
-status: active
+status: completed
 date: 2026-06-08
 origin: docs/brainstorms/2026-06-08-sops-recipient-scoping-requirements.md
 ---

--- a/docs/wiki/agent-operations.md
+++ b/docs/wiki/agent-operations.md
@@ -120,6 +120,10 @@ All secrets are sops-encrypted under `secrets/`. The repo uses a fallback resolv
 
 Implementation: `modules/nixos/common/secrets.nix`.
 
+**Secrets are per-host scoped (#234, 2026-06-08).** Layout *is* scope: a file under `secrets/hosts/<H>/` decrypts only on host `<H>` — never fleet-wide. Each secret is encrypted to its consuming host key(s) plus two universal keys: a cold **break-glass** key (recovery only, on no host) and a warm **editor** key (doc1-only, used to edit/re-key from the bastion). The `.sops.yaml` rules are enforced by `sopsRecipientScopeCheck` in `flake.nix`, with a fail-closed `.*` fallback so a new, unscoped secret deploys nowhere until given a rule. The old "every host decrypts every secret" / "master key" model is retired — see [`docs/wiki/infrastructure/sops-break-glass-recovery.md`](infrastructure/sops-break-glass-recovery.md) for the full recipient model and recovery procedures.
+
+**MCP control creds are doc1-only.** Credentials for pfsense / unifi / homeassistant / slskd / vinsight / audiobookshelf / paperless control APIs decrypt only on doc1 (`homelab.mcp` defaults off; doc1 opts in). doc2's metrics exporter uses a dedicated **read-only** pfSense key (user `metrics-exporter-ro`); the full-control pfSense key is doc1-only.
+
 ### Service -> secret map
 
 | Service | sops entry | File on disk (encrypted) | Decrypted to |
@@ -134,7 +138,7 @@ Implementation: `modules/nixos/common/secrets.nix`.
 - **Safe to print:** the *names* of secrets, sopsFile paths in this repo, the encrypted blobs themselves.
 - The `.sops.yaml` Age public keys at `secrets/.sops.yaml` are public by design.
 
-To edit a secret: use the `sops-decrypt` skill (it handles the keyring + sops binary). Direct `sops` invocations also work if the agent's host is in `.sops.yaml`.
+To edit a secret: use the `sops-decrypt` skill (it handles the keyring + sops binary). Direct `sops` invocations work where a usable age key is present — in practice the **editor** key lives only on doc1 (`~/.config/sops/age/keys.txt`), so routine `sops edit`/`sops updatekeys` happens from the bastion. A given host can also decrypt secrets scoped to its own key.
 
 ---
 

--- a/docs/wiki/infrastructure/ssh-bastion-model.md
+++ b/docs/wiki/infrastructure/ssh-bastion-model.md
@@ -3,6 +3,12 @@
 **Status:** live (shipped via [#270](https://github.com/abl030/nixosconfig/issues/270), 2026-06-08). No-infra interim ahead of the full CA architecture in [#241](https://github.com/abl030/nixosconfig/issues/241).
 **Researched/written:** 2026-06-08 (during the #270 work + its ce-code-review pass).
 
+> **Scope:** this doc covers **host access** — who can SSH where. The
+> complementary **secret layer** — who can `sops -d` what — is least-privilege
+> as of [#234](https://github.com/abl030/nixosconfig/issues/234) (per-host
+> recipient scoping + cold break-glass / warm editor keys); see
+> [sops-break-glass-recovery.md](./sops-break-glass-recovery.md).
+
 ## The problem it solves
 
 Before #270, every host deployed the **same** fleet SSH private key
@@ -55,8 +61,11 @@ a **no-expiry**, Contents:read, 2-repo fine-grained token.
 
 ## Gotchas / operational notes
 
-- **Break-glass:** Proxmox console on prom (console login is unaffected by
-  `secure=true`). If you lose all `bastionKeys`, that's the only way back in.
+- **Break-glass (host access):** Proxmox console on prom (console login is
+  unaffected by `secure=true`). If you lose all `bastionKeys`, that's the only
+  way back in. This is distinct from the **secret** break-glass key (the cold
+  age key in [#234](https://github.com/abl030/nixosconfig/issues/234) that
+  recovers `sops`-encrypted secrets) — different layer, different key.
 - **Lateral service hops need a dedicated key.** A keyless host can't SSH to a
   sibling with the fleet key any more. `gwm-archiver` on doc2 (which triggers
   `marker-convert` on epi) hit this — fixed with a dedicated, **forced-command**

--- a/docs/wiki/nixos-service-modules.md
+++ b/docs/wiki/nixos-service-modules.md
@@ -546,6 +546,8 @@ sops.secrets."<service>/env" = {
 
 The `sopsFile` helper searches: `secrets/hosts/<hostname>/` -> `secrets/users/<user>/` -> `secrets/`.
 
+**Layout is scope (#234, 2026-06-08).** A secret under `secrets/hosts/<host>/` is encrypted to *that host's* key only (plus the universal editor + break-glass keys) — it does not decrypt fleet-wide. Put a service's secret under its host's directory unless it is genuinely consumed on multiple hosts, in which case add an explicit multi-host rule in `secrets/.sops.yaml`. The recipient scoping is enforced by `sopsRecipientScopeCheck` in `flake.nix`, with a fail-closed `.*` fallback (editor + break-glass only) so a new, unscoped secret deploys to no host until given a rule. Full recipient model + recovery: [`docs/wiki/infrastructure/sops-break-glass-recovery.md`](infrastructure/sops-break-glass-recovery.md).
+
 ## Host Assignment
 
 Services are enabled in host configs (`hosts/<host>/configuration.nix`):

--- a/docs/wiki/services/home-assistant-deploy.md
+++ b/docs/wiki/services/home-assistant-deploy.md
@@ -14,7 +14,7 @@
 - Port 22 on `192.168.1.20` is exposed by the **Advanced SSH & Web Terminal** community add-on. Port 22222 (official Terminal & SSH add-on) is NOT installed.
 - User: `abl030`, UID 1000, in `wheel`. **Passwordless sudo.**
 - **Authorized keys** are configured via the SSH add-on's `authorized_keys:` option in the HA UI (Settings → Add-ons → Advanced SSH & Web Terminal → Configuration). On first auth they get installed into `/home/abl030/.ssh/authorized_keys`.
-- The master fleet identity (`~/.ssh/id_ed25519` from doc1/proxmox-vm, fingerprint `master-fleet-identity`) is authorized as of 2026-05-25.
+- The doc1 bastion's fleet SSH key (`~/.ssh/id_ed25519` on doc1/proxmox-vm, comment `master-fleet-identity`) is authorized as of 2026-05-25. This is the single doc1-only fleet key (see [ssh-bastion-model.md](../infrastructure/ssh-bastion-model.md)), not a fleet-wide or separate "master" key — siblings are keyless and reach HA via doc1.
 
 ### Quick connectivity test
 

--- a/docs/wiki/services/nixos-upgrade-diagnose.md
+++ b/docs/wiki/services/nixos-upgrade-diagnose.md
@@ -26,14 +26,13 @@ ssh <host> 'sudo -u <user> --login claude'
 
 Replace `<user>` with the host's `hostConfig.user` (usually `abl030`; `nixos` on wsl). Walk through the OAuth prompts in a browser, then exit. The token persists across reboots and through token refreshes. If it ever expires, the diagnose unit silently falls back to raw-log Gotify and you'll see `(claude triage unavailable, raw log tail follows)` at the top of the Gotify message — re-run the bootstrap to fix.
 
-Hosts to bootstrap (everything with `homelab.update.enable = true`, which is the base default — i.e. everything except `sandbox`):
+Hosts to bootstrap (everything with `homelab.update.enable = true`, which is the base default — i.e. the whole fleet):
 
 - proxmox-vm (doc1)
 - doc2
 - igpu
 - epimetheus
 - framework
-- dev
 - cache
 - wsl (user is `nixos`, not `abl030`)
 

--- a/readme.md
+++ b/readme.md
@@ -99,9 +99,14 @@ shared service becomes its own tailnet node — no broad network exposure.
 declares:
 
 - Identity (hostname, ssh alias, user, home dir)
-- Trust (SSH host key, authorized keys, master fleet identity)
+- Trust (SSH host key, authorized keys, the doc1-only fleet SSH key)
 - Syncthing device ID
 - Tailscale IP and LAN IP
+
+Trust is least-privilege on both layers: the fleet SSH key lives on doc1 only
+(the [SSH bastion](docs/wiki/infrastructure/ssh-bastion-model.md)), and sops
+secrets are scoped per-host with cold break-glass / warm editor keys (the
+[secret layer](docs/wiki/infrastructure/sops-break-glass-recovery.md)).
 
 A factory in [`nix/lib.nix`](nix/lib.nix) reads it and produces NixOS
 systems or standalone Home Manager configs. Add a host entry, drop in a
@@ -158,7 +163,6 @@ but it's nice that they all just work.
 - **doc2** — service appliance VM (immich, paperless, mealie,
   cratedigger, slskd, musicbrainz, kopia, uptime-kuma, the LGTM stack…)
 - **igpu** — media transcoding VM with AMD iGPU passthrough
-- **dev** — sandbox dev VM
 - **cache** — pull-through nix cache
 - **caddy** — a small server, Home Manager only
 


### PR DESCRIPTION
Full doc-run after #234 shipped: updates every doc made stale by the per-host sops scoping, break-glass/editor keys, master retirement, MCP→doc1-only, pfSense token split, and dev/sandbox decommission. Surgical edits only (CLAUDE.md/AGENTS.md, root readme, 6 wiki docs, memory, plan status flip). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)